### PR TITLE
fix(server): correct Count field in registerHAMi

### DIFF
--- a/server.go
+++ b/server.go
@@ -192,7 +192,7 @@ func (ps *PluginServer) registerHAMi() error {
 		apiDevices = append(apiDevices, &api.DeviceInfo{
 			Index:   i,
 			ID:      dev.UUID,
-			Count:   1,
+			Count:   int32(ps.mgr.VDeviceCount()),
 			Devmem:  int32(dev.Memory),
 			Devcore: dev.AICore,
 			Type:    ps.mgr.CommonWord(),


### PR DESCRIPTION

This PR fixes the issue #5 where NPUs couldn't be shared across multiple Pods due to the Count field being hard-coded to 1 in the Node Annotations. This limited each NPU instance to a single Pod, preventing resource sharing.

The fix replaces Count: 1 with Count: int32(ps.mgr.VDeviceCount()), which uses the VDeviceCount function to calculate the maximum allocatable count based on available memory and the smallest template size. This change allows NPUs to be shared across Pods as expected.