### PR TITLE
fix: exception happen when creating multiple ascend-gpu pods concurrently

### DIFF
--- a/ascend-device-plugin-2.4.0.yaml
+++ b/ascend-device-plugin-2.4.0.yaml
@@ -9,7 +9,7 @@ rules:
     verbs: ["get", "list", "update", "watch", "patch"]
   - apiGroups: [""]
     resources: ["nodes"]
-    verbs: ["get", "patch"]
+    verbs: ["get", "update", "patch"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/ascend-device-plugin-2.4.1.yaml
+++ b/ascend-device-plugin-2.4.1.yaml
@@ -9,7 +9,7 @@ rules:
     verbs: ["get", "list", "update", "watch", "patch"]
   - apiGroups: [""]
     resources: ["nodes"]
-    verbs: ["get", "patch"]
+    verbs: ["get", "update", "patch"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
What type of PR is this?
/kind bug

What this PR does / why we need it:
fix: exception occurred while creating multiple pods with ascend gpu concurrently,  release node lock
together with PR：https://github.com/Project-HAMi/HAMi/pull/575

Which issue(s) this PR fixes:
Fixes #

Special notes for your reviewer:

Does this PR introduce a user-facing change?: