### PR TITLE
fix: so load error

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
           mkdir -p ./artifacts
           cp libvnpu/target/release/limiter ./artifacts/
           cp libvnpu/target/release/libvnpu.so ./artifacts/
-          echo "/vnpu/libvnpu.so" > ./artifacts/ld.so.preload
+          echo "/hami-vnpu-core/libvnpu.so" > ./artifacts/ld.so.preload
       - name: upload artifacts
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
The .so file is mounted to `/hami-vnpu-core`, but the path in ld.so.preload is `/vnpu`.

<img width="1337" height="51" alt="ScreenShot_2026-04-27_113507_092" src="https://github.com/user-attachments/assets/089b7384-edc7-4a77-b994-2c9457228993" />

https://github.com/Project-HAMi/ascend-device-plugin/blob/349eaf5886ee7f8e881d3040a89065540b5ef051/internal/server/server.go#L562