### PR TITLE
fix error handling

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -36,7 +36,7 @@ import (
 var (
 	hwLoglevel            = flag.Int("hw_loglevel", 0, "huawei log level, -1-debug, 0-info, 1-warning, 2-error 3-critical default value: 0")
 	configFile            = flag.String("config_file", "", "config file path")
-	nodeConfigFile = flag.String("node_config_file", "", "node specific config file path") 
+	nodeConfigFile        = flag.String("node_config_file", "", "node specific config file path")
 	nodeName              = flag.String("node_name", os.Getenv("NODE_NAME"), "node name")
 	checkIdleVNPUInterval = flag.Int("check_idle_vnpu_interval", 60, "the interval (in seconds) to check idle vNPU and release them")
 )

--- a/internal/manager/manager.go
+++ b/internal/manager/manager.go
@@ -39,11 +39,11 @@ type Device struct {
 }
 
 type AscendManager struct {
-	mgr        *devmanager.DeviceManager
-	config     internal.VNPUConfig
+	mgr          *devmanager.DeviceManager
+	config       internal.VNPUConfig
 	globalConfig internal.Config
-	devs       []*Device
-	nodeConfig *internal.NodeConfig
+	devs         []*Device
+	nodeConfig   *internal.NodeConfig
 }
 
 func NewAscendManager() (*AscendManager, error) {
@@ -58,7 +58,7 @@ func NewAscendManager() (*AscendManager, error) {
 }
 
 func (am *AscendManager) LoadNodeConfig(nodePath string, nodeName string) error {
-	nodeConfigList, err := internal.LoadNodeConfig(nodePath) 
+	nodeConfigList, err := internal.LoadNodeConfig(nodePath)
 	if err != nil {
 		klog.Warningf("Failed to load node config from %s: %v", nodePath, err)
 		return err
@@ -71,7 +71,7 @@ func (am *AscendManager) LoadNodeConfig(nodePath string, nodeName string) error 
 			return nil
 		}
 	}
- 
+
 	klog.Infof("No specific config found for node %s, will use default settings", nodeName)
 	return nil
 }
@@ -254,9 +254,8 @@ func (am *AscendManager) CleanupIdleVNPUs() error {
 	return nil
 }
 
-
 func (am *AscendManager) GetNodeConfig() *internal.NodeConfig {
-    return am.nodeConfig
+	return am.nodeConfig
 }
 
 func (am *AscendManager) IsHamiVnpuCore() bool {

--- a/internal/manager/manager.go
+++ b/internal/manager/manager.go
@@ -190,6 +190,7 @@ func (am *AscendManager) GetDeviceByUUID(UUID string) *Device {
 func (am *AscendManager) GetIDs() []int32 {
 	_, IDs, err := am.mgr.GetDeviceList()
 	if err != nil {
+		klog.Errorf("failed to get device list: %v", err)
 		return nil
 	}
 	return IDs
@@ -204,6 +205,7 @@ func (am *AscendManager) GetUnHealthIDs() []int32 {
 	for _, d := range IDs {
 		healthCode, err := am.mgr.GetDeviceHealth(d)
 		if err != nil {
+			klog.Warningf("failed to get device health for %d: %v", d, err)
 			continue
 		}
 		if healthCode != 0 {

--- a/internal/manager/manager.go
+++ b/internal/manager/manager.go
@@ -218,7 +218,7 @@ func (am *AscendManager) CleanupIdleVNPUs() error {
 
 	_, IDs, err := am.mgr.GetDeviceList()
 	if err != nil {
-		return fmt.Errorf("failed to get device list: %v", err)
+		return fmt.Errorf("failed to get device list: %w", err)
 	}
 	klog.Infof("Found %d devices to check for idle vNPUs,%+v", len(IDs), IDs)
 

--- a/internal/manager/manager.go
+++ b/internal/manager/manager.go
@@ -51,7 +51,7 @@ type AscendManager struct {
 func NewAscendManager() (*AscendManager, error) {
 	mgr, err := devmanager.AutoInit("", 30)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to auto-init device manager: %w", err)
 	}
 	return &AscendManager{
 		mgr:  mgr,
@@ -81,11 +81,11 @@ func (am *AscendManager) LoadNodeConfig(nodePath string, nodeName string) error 
 func (am *AscendManager) LoadConfig(path string) error {
 	config, err := internal.LoadConfig(path)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to load config from %s: %w", path, err)
 	}
 	chipInfo, err := am.mgr.GetValidChipInfo()
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to get valid chip info: %w", err)
 	}
 	if chipInfo.Type != "Ascend" {
 		return fmt.Errorf("chip type is not Ascend")

--- a/internal/manager/manager.go
+++ b/internal/manager/manager.go
@@ -19,6 +19,7 @@ package manager
 import (
 	"fmt"
 	"sort"
+	"sync"
 
 	"ascend-common/devmanager"
 	"ascend-common/devmanager/dcmi"
@@ -39,6 +40,7 @@ type Device struct {
 }
 
 type AscendManager struct {
+	mu           sync.RWMutex
 	mgr          *devmanager.DeviceManager
 	config       internal.VNPUConfig
 	globalConfig internal.Config
@@ -129,7 +131,7 @@ func (am *AscendManager) UpdateDevice() error {
 		return err
 	}
 
-	am.devs = make([]*Device, 0, len(IDs))
+	newDevs := make([]*Device, 0, len(IDs))
 	for _, ID := range IDs {
 		phyID, err := am.mgr.GetPhysicIDFromLogicID(ID)
 		if err != nil {
@@ -151,7 +153,7 @@ func (am *AscendManager) UpdateDevice() error {
 			klog.Errorf("failed to get device health: %v", err)
 			return err
 		}
-		am.devs = append(am.devs, &Device{
+		newDevs = append(newDevs, &Device{
 			UUID:     uuid,
 			LogicID:  ID,
 			PhyID:    phyID,
@@ -162,14 +164,21 @@ func (am *AscendManager) UpdateDevice() error {
 			Health:   health == 0,
 		})
 	}
+	am.mu.Lock()
+	am.devs = newDevs
+	am.mu.Unlock()
 	return nil
 }
 
 func (am *AscendManager) GetDevices() []*Device {
+	am.mu.RLock()
+	defer am.mu.RUnlock()
 	return am.devs
 }
 
 func (am *AscendManager) GetDeviceByUUID(UUID string) *Device {
+	am.mu.RLock()
+	defer am.mu.RUnlock()
 	for _, dev := range am.devs {
 		if dev.UUID == UUID {
 			return dev

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -21,15 +21,20 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
+	"io"
 	"net"
 	"os"
 	"path"
+	"strconv"
 	"strings"
 	"time"
-	"strconv"
 
 	"github.com/Project-HAMi/HAMi/pkg/device"
 	// "github.com/Project-HAMi/HAMi/pkg/device/ascend"
+	"crypto/sha256"
+	"encoding/hex"
+	"path/filepath"
+
 	"github.com/Project-HAMi/HAMi/pkg/util"
 	"github.com/Project-HAMi/HAMi/pkg/util/nodelock"
 	"github.com/Project-HAMi/ascend-device-plugin/internal/manager"
@@ -38,20 +43,16 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/klog/v2"
 	"k8s.io/kubelet/pkg/apis/deviceplugin/v1beta1"
-	"io"
-	"path/filepath"
-	"crypto/sha256"
-    "encoding/hex"
 )
 
 const (
 	// RegisterAnnos = "hami.io/node-register-ascend"
 	// PodAllocAnno = "huawei.com/AscendDevices"
-	NodeLockAscend  = "hami.io/mutex.lock"
-	Ascend910Prefix = "Ascend910"
-	Ascend910CType  = "Ascend910C"
-	VNPUModeAnnotation     = "huawei.com/vnpu-mode"
-    VNPUModeHamiCore       = "hami-core"
+	NodeLockAscend             = "hami.io/mutex.lock"
+	Ascend910Prefix            = "Ascend910"
+	Ascend910CType             = "Ascend910C"
+	VNPUModeAnnotation         = "huawei.com/vnpu-mode"
+	VNPUModeHamiCore           = "hami-core"
 	VNPUNodeSelectorAnnotation = "hami-vnpu-core"
 )
 
@@ -73,10 +74,10 @@ type PluginServer struct {
 }
 
 type RuntimeInfo struct {
-	UUID     string `json:"UUID,omitempty"`
-	Temp     string `json:"temp,omitempty"`
-	Memory *int64  `json:"memory,omitempty"` 
-	Core *int32  `json:"core,omitempty"` 
+	UUID   string `json:"UUID,omitempty"`
+	Temp   string `json:"temp,omitempty"`
+	Memory *int64 `json:"memory,omitempty"`
+	Core   *int32 `json:"core,omitempty"`
 }
 
 func NewPluginServer(mgr *manager.AscendManager, nodeName string, checkIdleVNPUInterval int) (*PluginServer, error) {
@@ -96,116 +97,115 @@ func NewPluginServer(mgr *manager.AscendManager, nodeName string, checkIdleVNPUI
 
 // fileSHA256 calculates the SHA256 checksum of the specified file
 func fileSHA256(path string) (string, error) {
-    f, err := os.Open(path)  
-    if err != nil {
-        return "", err
-    }
-    defer f.Close()
-    
-    h := sha256.New()  
-    if _, err := io.Copy(h, f); err != nil {  
-        return "", err
-    }
-    return hex.EncodeToString(h.Sum(nil)), nil  
+	f, err := os.Open(path)
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(h.Sum(nil)), nil
 }
 
 // Automatically creates directories, sets permissions, and copies core files on the host
 func prepareHostResources() error {
-    klog.Info("Starting host resource preparation for HAMi vNPU core...")
+	klog.Info("Starting host resource preparation for HAMi vNPU core...")
 
-    // 1. Create shared memory directory
-    sharedRegionPath := "/usr/local/hami-shared-region"
-    if err := os.MkdirAll(sharedRegionPath, 0777); err != nil {
-        if !os.IsExist(err) {
-            return fmt.Errorf("failed to create %s: %w", sharedRegionPath, err)
-        }
-    }
-    if err := os.Chmod(sharedRegionPath, 0777); err != nil {
-        return fmt.Errorf("failed to chmod %s: %w", sharedRegionPath, err)
-    }
-    klog.Infof("Successfully prepared directory: %s", sharedRegionPath)
+	// 1. Create shared memory directory
+	sharedRegionPath := "/usr/local/hami-shared-region"
+	if err := os.MkdirAll(sharedRegionPath, 0777); err != nil {
+		if !os.IsExist(err) {
+			return fmt.Errorf("failed to create %s: %w", sharedRegionPath, err)
+		}
+	}
+	if err := os.Chmod(sharedRegionPath, 0777); err != nil {
+		return fmt.Errorf("failed to chmod %s: %w", sharedRegionPath, err)
+	}
+	klog.Infof("Successfully prepared directory: %s", sharedRegionPath)
 
-    // 2. Prepare /usr/local/hami-vnpu-core/ directory
-    targetDir := "/usr/local/hami-vnpu-core"
-    if err := os.MkdirAll(targetDir, 0775); err != nil {
-        return fmt.Errorf("failed to create %s: %w", targetDir, err)
-    }
+	// 2. Prepare /usr/local/hami-vnpu-core/ directory
+	targetDir := "/usr/local/hami-vnpu-core"
+	if err := os.MkdirAll(targetDir, 0775); err != nil {
+		return fmt.Errorf("failed to create %s: %w", targetDir, err)
+	}
 
-    // Specify the in-container assets directory (can be overridden via environment variable, default follows standard DevicePlugin convention)
-    assetsDir := os.Getenv("HAMI_VNPU_ASSETS_PATH")
-    if assetsDir == "" {
-        assetsDir = "/usr/local/hami-vnpu-core-assets"
-    }
+	// Specify the in-container assets directory (can be overridden via environment variable, default follows standard DevicePlugin convention)
+	assetsDir := os.Getenv("HAMI_VNPU_ASSETS_PATH")
+	if assetsDir == "" {
+		assetsDir = "/usr/local/hami-vnpu-core-assets"
+	}
 
-    // Define files to copy: source path in container -> target path on host
-    filesToCopy := map[string]string{
-        "limiter":       filepath.Join(targetDir, "limiter"),
-        "libvnpu.so":    filepath.Join(targetDir, "libvnpu.so"),
-        "ld.so.preload": filepath.Join(targetDir, "ld.so.preload"),
-    }
+	// Define files to copy: source path in container -> target path on host
+	filesToCopy := map[string]string{
+		"limiter":       filepath.Join(targetDir, "limiter"),
+		"libvnpu.so":    filepath.Join(targetDir, "libvnpu.so"),
+		"ld.so.preload": filepath.Join(targetDir, "ld.so.preload"),
+	}
 
-    for srcName, destPath := range filesToCopy {
-        srcPath := filepath.Join(assetsDir, srcName)
+	for srcName, destPath := range filesToCopy {
+		srcPath := filepath.Join(assetsDir, srcName)
 
 		// File already exists, skip if content is consistent
 		if _, err := os.Stat(destPath); err == nil {
-            srcSum, err1 := fileSHA256(srcPath)
-            dstSum, err2 := fileSHA256(destPath)
-            
-            if err1 == nil && err2 == nil && srcSum == dstSum {
-                klog.Infof("✓ %s already up-to-date, skipping", destPath)
-                continue
-            }
-        }
+			srcSum, err1 := fileSHA256(srcPath)
+			dstSum, err2 := fileSHA256(destPath)
 
-        if err := copyFile(srcPath, destPath); err != nil {
-            if strings.Contains(err.Error(), "text file busy") {
-                klog.Warningf("⚠ %s is in use by running process, keeping existing version (safe)", destPath)
-                continue
-            }
-            return fmt.Errorf("failed to copy %s: %w", destPath, err)
-        }
-        klog.Infof("✓ Copied %s -> %s", srcPath, destPath)
-    }
+			if err1 == nil && err2 == nil && srcSum == dstSum {
+				klog.Infof("✓ %s already up-to-date, skipping", destPath)
+				continue
+			}
+		}
 
-    klog.Info("Host resource preparation completed successfully.")
-    return nil
+		if err := copyFile(srcPath, destPath); err != nil {
+			if strings.Contains(err.Error(), "text file busy") {
+				klog.Warningf("⚠ %s is in use by running process, keeping existing version (safe)", destPath)
+				continue
+			}
+			return fmt.Errorf("failed to copy %s: %w", destPath, err)
+		}
+		klog.Infof("✓ Copied %s -> %s", srcPath, destPath)
+	}
+
+	klog.Info("Host resource preparation completed successfully.")
+	return nil
 }
 
 // A standard file copy implementation that preserves the original file permissions
 func copyFile(src, dst string) error {
-    srcFile, err := os.Open(src)
-    if err != nil {
-        return err
-    }
-    defer srcFile.Close()
+	srcFile, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer srcFile.Close()
 
-    dstFile, err := os.Create(dst)
-    if err != nil {
-        return err
-    }
-    defer dstFile.Close()
+	dstFile, err := os.Create(dst)
+	if err != nil {
+		return err
+	}
+	defer dstFile.Close()
 
-    if _, err = io.Copy(dstFile, srcFile); err != nil {
-        return err
-    }
+	if _, err = io.Copy(dstFile, srcFile); err != nil {
+		return err
+	}
 
-    // Sync source file permissions (ensure the limiter binary retains executable permission)
-    srcInfo, err := srcFile.Stat()
-    if err != nil {
-        return err
-    }
-    return os.Chmod(dst, srcInfo.Mode())
+	// Sync source file permissions (ensure the limiter binary retains executable permission)
+	srcInfo, err := srcFile.Stat()
+	if err != nil {
+		return err
+	}
+	return os.Chmod(dst, srcInfo.Mode())
 }
-
 
 func (ps *PluginServer) Start() error {
 	// Automatically prepare host environment when the plugin starts
-    if err := prepareHostResources(); err != nil {
-        klog.Errorf("Failed to prepare host resources: %v. vNPU core functionality will be impaired.", err)
-        return err
-    }
-	
+	if err := prepareHostResources(); err != nil {
+		klog.Errorf("Failed to prepare host resources: %v. vNPU core functionality will be impaired.", err)
+		return err
+	}
+
 	ps.stopCh = make(chan interface{})
 	err := ps.mgr.UpdateDevice()
 	if err != nil {
@@ -388,14 +388,14 @@ func (ps *PluginServer) registerHAMi() error {
 	annos := make(map[string]string)
 	annos[ps.registerAnno] = device.MarshalNodeDevices(apiDevices)
 	annos[ps.handshakeAnno] = "Reported_" + time.Now().Add(time.Duration(*reportTimeOffset)*time.Second).Format("2006.01.02 15:04:05")
-	
+
 	if ps.mgr.IsHamiVnpuCore() {
 		annos[VNPUNodeSelectorAnnotation] = "true"
 		klog.V(4).Infof("Node %s has HamiVnpuCore enabled, patching annotation %s: true", ps.nodeName, VNPUNodeSelectorAnnotation)
 	} else {
 		annos[VNPUNodeSelectorAnnotation] = "false"
 	}
-	
+
 	node, err := util.GetNode(ps.nodeName)
 	if err != nil {
 		return fmt.Errorf("get node %s error: %w", ps.nodeName, err)
@@ -437,21 +437,20 @@ func (ps *PluginServer) watchAndRegister() {
 	}
 }
 
-
 func (ps *PluginServer) parsePodAnnotation(pod *v1.Pod) ([]int32, []string, []*int64, []*int32, error) {
 	anno, ok := pod.Annotations[ps.allocAnno]
 	if !ok {
-		return nil, nil,nil, nil, fmt.Errorf("annotation %s not set", "huawei.com/Ascend")
+		return nil, nil, nil, nil, fmt.Errorf("annotation %s not set", "huawei.com/Ascend")
 	}
 	var rtInfo []RuntimeInfo
 	err := json.Unmarshal([]byte(anno), &rtInfo)
 	if err != nil {
-		return nil, nil,nil, nil, fmt.Errorf("annotation %s value %s invalid: %w", ps.allocAnno, anno, err)
+		return nil, nil, nil, nil, fmt.Errorf("annotation %s value %s invalid: %w", ps.allocAnno, anno, err)
 	}
 	var IDs []int32
 	var temps []string
-	var memories []*int64  
-    var cores []*int32 
+	var memories []*int64
+	var cores []*int32
 
 	for _, info := range rtInfo {
 		if info.UUID == "" {
@@ -465,10 +464,10 @@ func (ps *PluginServer) parsePodAnnotation(pod *v1.Pod) ([]int32, []string, []*i
 		temps = append(temps, info.Temp)
 		if info.Memory != nil {
 			memories = append(memories, info.Memory)
-		} 
+		}
 		if info.Core != nil {
 			cores = append(cores, info.Core)
-		} 
+		}
 	}
 	if len(IDs) == 0 {
 		return nil, nil, nil, nil, fmt.Errorf("annotation %s value %s invalid", ps.allocAnno, anno)
@@ -537,10 +536,10 @@ func (ps *PluginServer) Allocate(ctx context.Context, reqs *v1beta1.AllocateRequ
 	if err != nil {
 		return nil, fmt.Errorf("parse pod annotation error: %w", err)
 	}
-	
+
 	vnpuMode := pod.Annotations[VNPUModeAnnotation]
 	klog.V(4).Infof("Pod %s vnpu mode: %s", pod.Name, vnpuMode)
-	
+
 	if len(IDs) == 0 {
 		return nil, fmt.Errorf("empty id from pod annotation")
 	}
@@ -553,22 +552,22 @@ func (ps *PluginServer) Allocate(ctx context.Context, reqs *v1beta1.AllocateRequ
 	resp.Envs["ASCEND_VISIBLE_DEVICES"] = ascendVisibleDevices
 
 	if vnpuMode == VNPUModeHamiCore {
-		// 1. Handle volume mount injection 
+		// 1. Handle volume mount injection
 		var mounts []*v1beta1.Mount
 		// A.Huawei driver and SMI toolchain (Read-Only)
 		driverPaths := []string{
-					"/usr/local/bin/npu-smi",
-					"/etc/ascend_install.info",
-					"/usr/local/Ascend/driver/lib64/driver",
-					"/usr/local/Ascend/driver/version.info",
-			}
+			"/usr/local/bin/npu-smi",
+			"/etc/ascend_install.info",
+			"/usr/local/Ascend/driver/lib64/driver",
+			"/usr/local/Ascend/driver/version.info",
+		}
 		for _, p := range driverPaths {
 			mounts = append(mounts, &v1beta1.Mount{HostPath: p, ContainerPath: p, ReadOnly: true})
 		}
 
 		mounts = append(mounts, &v1beta1.Mount{
-			HostPath:      "/usr/local/hami-vnpu-core", 
-			ContainerPath: "/hami-vnpu-core",                      
+			HostPath:      "/usr/local/hami-vnpu-core",
+			ContainerPath: "/hami-vnpu-core",
 			ReadOnly:      true,
 		})
 		// B. Inject HAMi library path by mounting /etc/ld.so.preload.
@@ -580,12 +579,12 @@ func (ps *PluginServer) Allocate(ctx context.Context, reqs *v1beta1.AllocateRequ
 
 		// C. Shared directory for HAMi compute resource partitioning (Read/Write)
 		mounts = append(mounts, &v1beta1.Mount{
-			HostPath:      "/usr/local/hami-shared-region", 
+			HostPath:      "/usr/local/hami-shared-region",
 			ContainerPath: "/hami-shared-region",
 			ReadOnly:      false,
 		})
 		resp.Mounts = mounts
-		
+
 		// Set NPU_MEM_QUOTA
 		if len(memories) > 0 && memories[0] != nil {
 			resp.Envs["NPU_MEM_QUOTA"] = strconv.FormatInt(*memories[0], 10)

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -117,18 +117,18 @@ func prepareHostResources() error {
     sharedRegionPath := "/usr/local/hami-shared-region"
     if err := os.MkdirAll(sharedRegionPath, 0777); err != nil {
         if !os.IsExist(err) {
-            return fmt.Errorf("failed to create %s: %v", sharedRegionPath, err)
+            return fmt.Errorf("failed to create %s: %w", sharedRegionPath, err)
         }
     }
     if err := os.Chmod(sharedRegionPath, 0777); err != nil {
-        return fmt.Errorf("failed to chmod %s: %v", sharedRegionPath, err)
+        return fmt.Errorf("failed to chmod %s: %w", sharedRegionPath, err)
     }
     klog.Infof("Successfully prepared directory: %s", sharedRegionPath)
 
     // 2. Prepare /usr/local/hami-vnpu-core/ directory
     targetDir := "/usr/local/hami-vnpu-core"
     if err := os.MkdirAll(targetDir, 0775); err != nil {
-        return fmt.Errorf("failed to create %s: %v", targetDir, err)
+        return fmt.Errorf("failed to create %s: %w", targetDir, err)
     }
 
     // Specify the in-container assets directory (can be overridden via environment variable, default follows standard DevicePlugin convention)
@@ -163,7 +163,7 @@ func prepareHostResources() error {
                 klog.Warningf("⚠ %s is in use by running process, keeping existing version (safe)", destPath)
                 continue
             }
-            return fmt.Errorf("failed to copy %s: %v", destPath, err)
+            return fmt.Errorf("failed to copy %s: %w", destPath, err)
         }
         klog.Infof("✓ Copied %s -> %s", srcPath, destPath)
     }
@@ -377,7 +377,7 @@ func (ps *PluginServer) registerHAMi() error {
 		if strings.HasPrefix(device.Type, Ascend910Prefix) {
 			NetworkID, err := ps.getDeviceNetworkID(i, device.Type)
 			if err != nil {
-				return fmt.Errorf("get networkID error: %v", err)
+				return fmt.Errorf("get networkID error: %w", err)
 			}
 			device.CustomInfo = map[string]any{
 				"NetworkID": NetworkID,
@@ -398,11 +398,11 @@ func (ps *PluginServer) registerHAMi() error {
 	
 	node, err := util.GetNode(ps.nodeName)
 	if err != nil {
-		return fmt.Errorf("get node %s error: %v", ps.nodeName, err)
+		return fmt.Errorf("get node %s error: %w", ps.nodeName, err)
 	}
 	err = util.PatchNodeAnnotations(node, annos)
 	if err != nil {
-		return fmt.Errorf("patch node %s annotations error: %v", ps.nodeName, err)
+		return fmt.Errorf("patch node %s annotations error: %w", ps.nodeName, err)
 	}
 	klog.V(5).Infof("patch node %s annotations: %v", ps.nodeName, annos)
 	return nil
@@ -446,7 +446,7 @@ func (ps *PluginServer) parsePodAnnotation(pod *v1.Pod) ([]int32, []string, []*i
 	var rtInfo []RuntimeInfo
 	err := json.Unmarshal([]byte(anno), &rtInfo)
 	if err != nil {
-		return nil, nil,nil, nil, fmt.Errorf("annotation %s value %s invalid", ps.allocAnno, anno)
+		return nil, nil,nil, nil, fmt.Errorf("annotation %s value %s invalid: %w", ps.allocAnno, anno, err)
 	}
 	var IDs []int32
 	var temps []string
@@ -530,12 +530,12 @@ func (ps *PluginServer) Allocate(ctx context.Context, reqs *v1beta1.AllocateRequ
 	pod, err := util.GetPendingPod(ctx, ps.nodeName)
 	if err != nil {
 		klog.Errorf("get pending pod error: %v", err)
-		return nil, fmt.Errorf("get pending pod error: %v", err)
+		return nil, fmt.Errorf("get pending pod error: %w", err)
 	}
 	resp := v1beta1.ContainerAllocateResponse{}
 	IDs, temps, memories, cores, err := ps.parsePodAnnotation(pod)
 	if err != nil {
-		return nil, fmt.Errorf("parse pod annotation error: %v", err)
+		return nil, fmt.Errorf("parse pod annotation error: %w", err)
 	}
 	
 	vnpuMode := pod.Annotations[VNPUModeAnnotation]

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -534,13 +534,9 @@ func (ps *PluginServer) buildContainerAllocateResponse(pod *v1.Pod, containerDev
 			klog.V(4).InfoS("Core priority set", "value", *cores[0])
 		}
 
-		// Set GLOBAL_SHM_PATH separated by device ID.
-		if len(IDs) > 0 {
-			resp.Envs["NPU_GLOBAL_SHM_PATH"] = fmt.Sprintf("/hami-shared-region/%d_global_registry", IDs[0])
-			klog.V(5).Infof("Create %d_global_registry", IDs[0])
-		} else {
-			klog.Warningf("No device IDs allocated")
-		}
+		// Set GLOBAL_SHM_PATH based on the first device ID.
+		resp.Envs["NPU_GLOBAL_SHM_PATH"] = fmt.Sprintf("/hami-shared-region/%d_global_registry", IDs[0])
+		klog.V(5).Infof("Create %d_global_registry", IDs[0])
 	} else {
 		if ascendVNPUSpec != "" {
 			resp.Envs["ASCEND_VNPU_SPECS"] = ascendVNPUSpec

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -293,6 +293,11 @@ func (ps *PluginServer) serve() error {
 		lastCrashTime := time.Now()
 		restartCount := 0
 		for {
+			select {
+			case <-ps.stopCh:
+				return
+			default:
+			}
 			klog.Infof("Starting GRPC server for '%s'", resourceName)
 			err := ps.grpcServer.Serve(sock)
 			if err == nil {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -329,7 +329,7 @@ func (ps *PluginServer) serve() error {
 	// Wait for server to start by launching a blocking connexion
 	conn, err := ps.dial(ps.socket, 5*time.Second)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to dial device plugin socket: %w", err)
 	}
 	_ = conn.Close()
 
@@ -339,7 +339,7 @@ func (ps *PluginServer) serve() error {
 func (ps *PluginServer) registerKubelet() error {
 	conn, err := ps.dial(v1beta1.KubeletSocket, 5*time.Second)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to dial kubelet socket: %w", err)
 	}
 	defer func(conn *grpc.ClientConn) {
 		_ = conn.Close()
@@ -356,7 +356,7 @@ func (ps *PluginServer) registerKubelet() error {
 
 	_, err = client.Register(context.Background(), reqt)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to register device plugin with kubelet: %w", err)
 	}
 	return nil
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -445,15 +445,8 @@ func (ps *PluginServer) watchAndRegister() {
 	}
 }
 
-// buildContainerAllocateResponse constructs the ContainerAllocateResponse for
-// the given container devices. It resolves UUIDs to PhyIDs and looks up vNPU
-// template names from the allocAnno annotation.
-func (ps *PluginServer) buildContainerAllocateResponse(pod *v1.Pod, containerDevs device.ContainerDevices) (*v1beta1.ContainerAllocateResponse, error) {
-	rtInfoLookup, err := ps.buildRuntimeInfoLookup(pod)
-	if err != nil {
-		return nil, fmt.Errorf("build runtimeInfo lookup: %w", err)
-	}
-
+// buildContainerAllocateResponse builds the allocate response for a single container.
+func (ps *PluginServer) buildContainerAllocateResponse(pod *v1.Pod, containerDevs device.ContainerDevices, rtInfoLookup map[string]RuntimeInfo) (*v1beta1.ContainerAllocateResponse, error) {
 	resp := &v1beta1.ContainerAllocateResponse{}
 
 	var (
@@ -556,31 +549,37 @@ func (ps *PluginServer) buildContainerAllocateResponse(pod *v1.Pod, containerDev
 	return resp, nil
 }
 
-// getNextContainerDevices reads the toAllocDeviceAnno annotation and returns
-// the devices of the first container that still has pending allocations.
-func (ps *PluginServer) getNextContainerDevices(pod *v1.Pod) (device.ContainerDevices, error) {
-	anno, ok := pod.Annotations[ps.toAllocDeviceAnno]
-	if !ok {
-		return nil, fmt.Errorf("annotation %s not found", ps.toAllocDeviceAnno)
-	}
-	podSingleDev, err := decodePodSingleDevice(anno)
-	if err != nil {
-		return nil, fmt.Errorf("decode annotation %s: %w", ps.toAllocDeviceAnno, err)
-	}
-	for _, ctrDevice := range podSingleDev {
-		if len(ctrDevice) > 0 {
-			return ctrDevice, nil
+// popNextContainerDevices finds and erases the first non-empty containerDevices
+// from podSingleDev. It mutates podSingleDev in place.
+func (ps *PluginServer) popNextContainerDevices(podSingleDev device.PodSingleDevice) (device.ContainerDevices, error) {
+	for i, ctrDevs := range podSingleDev {
+		if len(ctrDevs) > 0 {
+			podSingleDev[i] = device.ContainerDevices{}
+			return ctrDevs, nil
 		}
 	}
-	return nil, fmt.Errorf("no pending device allocation in annotation %s", ps.toAllocDeviceAnno)
+	return nil, fmt.Errorf("no pending device allocation found")
 }
 
-// buildTempLookup reads the allocAnno annotation and returns a map from
-// device UUID to its vNPU template name.
+// decodeDeviceAnnotations decodes the pod's device allocation annotation
+// (registered as hami.io/<commonword>-devices-to-allocate in InRequestDevices)
+// into a PodSingleDevice.
+func (ps *PluginServer) decodeDeviceAnnotations(pod *v1.Pod) (device.PodSingleDevice, error) {
+	pdevices, err := device.DecodePodDevices(device.InRequestDevices, pod.Annotations)
+	if err != nil {
+		return nil, err
+	}
+	pd, ok := pdevices[ps.commonWord]
+	if !ok {
+		return nil, fmt.Errorf("device %s not found in pod annotations", ps.commonWord)
+	}
+	return pd, nil
+}
+
+// buildRuntimeInfoLookup builds a UUID-to-RuntimeInfo lookup from the pod's allocAnno annotation.
 func (ps *PluginServer) buildRuntimeInfoLookup(pod *v1.Pod) (map[string]RuntimeInfo, error) {
 	anno, ok := pod.Annotations[ps.allocAnno]
 	if !ok {
-		// The annotation may not exist for non-vNPU scenarios; return empty lookup.
 		return nil, fmt.Errorf("annotation %s not set", ps.allocAnno)
 	}
 	var rtInfo []RuntimeInfo
@@ -596,105 +595,19 @@ func (ps *PluginServer) buildRuntimeInfoLookup(pod *v1.Pod) (map[string]RuntimeI
 	return lookup, nil
 }
 
-// eraseCurrentContainerAnnotation erases the current container's devices from
-// the toAllocDeviceAnno annotation, so the next Allocate call will advance
-// to the next container.
-func (ps *PluginServer) eraseCurrentContainerAnnotation(pod *v1.Pod) error {
-	anno, ok := pod.Annotations[ps.toAllocDeviceAnno]
-	if !ok {
-		return fmt.Errorf("annotation %s not found", ps.toAllocDeviceAnno)
-	}
-	podSingleDev, err := decodePodSingleDevice(anno)
-	if err != nil {
-		return fmt.Errorf("decode annotation %s: %w", ps.toAllocDeviceAnno, err)
-	}
-	res := make(device.PodSingleDevice, 0, len(podSingleDev))
-	found := false
-	for _, val := range podSingleDev {
-		if found {
-			res = append(res, val)
-		} else {
-			if len(val) > 0 {
-				found = true
-				res = append(res, device.ContainerDevices{})
-			} else {
-				res = append(res, val)
-			}
-		}
-	}
-	klog.V(5).Infof("After erase annotation, remaining devices: %v", res)
-	newAnnoValue := device.EncodePodSingleDevice(res)
+// patchErasedAnnotation patches the pod's device annotation with the given
+// podSingleDev. It also updates pod.Annotations in place.
+func (ps *PluginServer) patchErasedAnnotation(pod *v1.Pod, podSingleDev device.PodSingleDevice) error {
+	klog.V(5).Infof("After erase annotation, remaining devices: %v", podSingleDev)
+	newAnnoValue := device.EncodePodSingleDevice(podSingleDev)
 	newAnnos := map[string]string{
 		ps.toAllocDeviceAnno: newAnnoValue,
 	}
 	if err := util.PatchPodAnnotations(pod, newAnnos); err != nil {
 		return err
 	}
-	// Update in-memory pod annotations so subsequent getNextContainerDevices
-	// calls within the same Allocate see the erased state.
 	pod.Annotations[ps.toAllocDeviceAnno] = newAnnoValue
 	return nil
-}
-
-// decodePodSingleDevice decodes a single annotation value string into a
-// PodSingleDevice. It reuses HAMi's DecodeContainerDevices for per-device
-// parsing. The format is:
-//
-//	<ctr1-dev1>,<fields>:<ctr1-dev2>,<fields>;<ctr2-dev1>,<fields>;...
-func decodePodSingleDevice(str string) (device.PodSingleDevice, error) {
-	if len(str) == 0 {
-		return device.PodSingleDevice{}, nil
-	}
-	pd := make(device.PodSingleDevice, 0)
-	for _, s := range strings.Split(str, device.OnePodMultiContainerSplitSymbol) {
-		cd, err := device.DecodeContainerDevices(s)
-		if err != nil {
-			return nil, err
-		}
-		if len(cd) == 0 {
-			continue
-		}
-		pd = append(pd, cd)
-	}
-	return pd, nil
-}
-
-func (ps *PluginServer) parsePodAnnotation(pod *v1.Pod) ([]int32, []string, []*int64, []*int32, error) {
-	anno, ok := pod.Annotations[ps.allocAnno]
-	if !ok {
-		return nil, nil, nil, nil, fmt.Errorf("annotation %s not set", "huawei.com/Ascend")
-	}
-	var rtInfo []RuntimeInfo
-	err := json.Unmarshal([]byte(anno), &rtInfo)
-	if err != nil {
-		return nil, nil, nil, nil, fmt.Errorf("annotation %s value %s invalid: %w", ps.allocAnno, anno, err)
-	}
-	var IDs []int32
-	var temps []string
-	var memories []*int64
-	var cores []*int32
-
-	for _, info := range rtInfo {
-		if info.UUID == "" {
-			continue
-		}
-		d := ps.mgr.GetDeviceByUUID(info.UUID)
-		if d == nil {
-			return nil, nil, nil, nil, fmt.Errorf("unknown uuid: %s", info.UUID)
-		}
-		IDs = append(IDs, d.PhyID)
-		temps = append(temps, info.Temp)
-		if info.Memory != nil {
-			memories = append(memories, info.Memory)
-		}
-		if info.Core != nil {
-			cores = append(cores, info.Core)
-		}
-	}
-	if len(IDs) == 0 {
-		return nil, nil, nil, nil, fmt.Errorf("annotation %s value %s invalid", ps.allocAnno, anno)
-	}
-	return IDs, temps, memories, cores, nil
 }
 
 func (ps *PluginServer) apiDevices() []*v1beta1.Device {
@@ -753,16 +666,30 @@ func (ps *PluginServer) Allocate(ctx context.Context, reqs *v1beta1.AllocateRequ
 		}
 	}()
 
+	var err error
+	pod, err = util.GetPendingPod(ctx, ps.nodeName)
+	if err != nil {
+		klog.Errorf("get pending pod error: %v", err)
+		return nil, fmt.Errorf("get pending pod error: %w", err)
+	}
+	klog.Infof("allocating for pod %s/%s", pod.Namespace, pod.Name)
+
+	rtInfoLookup, err := ps.buildRuntimeInfoLookup(pod)
+	if err != nil {
+		return nil, fmt.Errorf("build runtimeInfo lookup: %w", err)
+	}
+
+	podSingleDev, err := ps.decodeDeviceAnnotations(pod)
+	if err != nil {
+		return nil, fmt.Errorf("decode device annotations: %w", err)
+	}
+
+	// kubelet may call Allocate multiple times for the same pod, each time with
+	// a subset of containers. Use pop semantics to match each request with its
+	// corresponding containerDevices.
 	responses := v1beta1.AllocateResponse{}
 	for _, req := range reqs.ContainerRequests {
-		pod, err := util.GetPendingPod(ctx, ps.nodeName)
-		if err != nil {
-			klog.Errorf("get pending pod error: %v", err)
-			return nil, fmt.Errorf("get pending pod error: %w", err)
-		}
-		klog.Infof("allocating for pod %s/%s", pod.Namespace, pod.Name)
-
-		containerDevs, err := ps.getNextContainerDevices(pod)
+		containerDevs, err := ps.popNextContainerDevices(podSingleDev)
 		if err != nil {
 			return nil, fmt.Errorf("get next container devices: %w", err)
 		}
@@ -772,18 +699,19 @@ func (ps *PluginServer) Allocate(ctx context.Context, reqs *v1beta1.AllocateRequ
 			return nil, fmt.Errorf("device number not matched: annotation has %d, request has %d", len(containerDevs), len(req.DevicesIDs))
 		}
 
-		resp, err := ps.buildContainerAllocateResponse(pod, containerDevs)
+		resp, err := ps.buildContainerAllocateResponse(pod, containerDevs, rtInfoLookup)
 		if err != nil {
 			return nil, fmt.Errorf("build container allocate response: %w", err)
 		}
-
-		if err := ps.eraseCurrentContainerAnnotation(pod); err != nil {
-			klog.Errorf("erase current container annotation error: %v", err)
-			return nil, fmt.Errorf("erase current container annotation: %w", err)
-		}
-
 		responses.ContainerResponses = append(responses.ContainerResponses, resp)
 	}
+
+	// Patch the annotation with the in-memory erased podSingleDev.
+	if err := ps.patchErasedAnnotation(pod, podSingleDev); err != nil {
+		klog.Errorf("erase allocated containers annotation error: %v", err)
+		return nil, fmt.Errorf("erase allocated containers annotation: %w", err)
+	}
+
 	klog.V(5).Infof("allocate response: %+v", responses.ContainerResponses)
 	success = true
 	return &responses, nil

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -18,6 +18,7 @@ package server
 
 import (
 	"context"
+	"encoding/json"
 	"flag"
 	"fmt"
 	"net"
@@ -35,7 +36,6 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 	v1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/util/json"
 	"k8s.io/klog/v2"
 	"k8s.io/kubelet/pkg/apis/deviceplugin/v1beta1"
 	"io"

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -30,6 +30,7 @@ import (
 	"time"
 
 	"github.com/Project-HAMi/HAMi/pkg/device"
+
 	// "github.com/Project-HAMi/HAMi/pkg/device/ascend"
 	"crypto/sha256"
 	"encoding/hex"
@@ -65,6 +66,7 @@ type PluginServer struct {
 	registerAnno          string
 	handshakeAnno         string
 	allocAnno             string
+	toAllocDeviceAnno     string
 	grpcServer            *grpc.Server
 	mgr                   *manager.AscendManager
 	socket                string
@@ -81,14 +83,16 @@ type RuntimeInfo struct {
 }
 
 func NewPluginServer(mgr *manager.AscendManager, nodeName string, checkIdleVNPUInterval int) (*PluginServer, error) {
+	commonWord := mgr.CommonWord()
 	return &PluginServer{
 		nodeName:              nodeName,
-		registerAnno:          fmt.Sprintf("hami.io/node-register-%s", mgr.CommonWord()),
-		handshakeAnno:         fmt.Sprintf("hami.io/node-handshake-%s", mgr.CommonWord()),
-		allocAnno:             fmt.Sprintf("huawei.com/%s", mgr.CommonWord()),
+		registerAnno:          fmt.Sprintf("hami.io/node-register-%s", commonWord),
+		handshakeAnno:         fmt.Sprintf("hami.io/node-handshake-%s", commonWord),
+		allocAnno:             fmt.Sprintf("huawei.com/%s", commonWord),
+		toAllocDeviceAnno:     fmt.Sprintf("hami.io/%s-devices-to-allocate", commonWord),
 		grpcServer:            grpc.NewServer(),
 		mgr:                   mgr,
-		socket:                path.Join(v1beta1.DevicePluginPath, fmt.Sprintf("%s.sock", mgr.CommonWord())),
+		socket:                path.Join(v1beta1.DevicePluginPath, fmt.Sprintf("%s.sock", commonWord)),
 		stopCh:                make(chan interface{}),
 		healthCh:              make(chan int32),
 		checkIdleVNPUInterval: checkIdleVNPUInterval,
@@ -437,6 +441,220 @@ func (ps *PluginServer) watchAndRegister() {
 	}
 }
 
+// buildContainerAllocateResponse constructs the ContainerAllocateResponse for
+// the given container devices. It resolves UUIDs to PhyIDs and looks up vNPU
+// template names from the allocAnno annotation.
+func (ps *PluginServer) buildContainerAllocateResponse(pod *v1.Pod, containerDevs device.ContainerDevices) (*v1beta1.ContainerAllocateResponse, error) {
+	rtInfoLookup, err := ps.buildRuntimeInfoLookup(pod)
+	if err != nil {
+		return nil, fmt.Errorf("build runtimeInfo lookup: %w", err)
+	}
+
+	resp := &v1beta1.ContainerAllocateResponse{}
+
+	var (
+		IDs            []int32
+		memories       []*int64
+		cores          []*int32
+		ascendVNPUSpec string
+	)
+
+	for _, dev := range containerDevs {
+		d := ps.mgr.GetDeviceByUUID(dev.UUID)
+		if d == nil {
+			return nil, fmt.Errorf("unknown uuid: %s", dev.UUID)
+		}
+		IDs = append(IDs, d.PhyID)
+
+		if info, ok := rtInfoLookup[dev.UUID]; ok {
+			if ascendVNPUSpec == "" && info.Temp != "" {
+				ascendVNPUSpec = info.Temp
+			}
+			if info.Memory != nil {
+				memories = append(memories, info.Memory)
+			}
+			if info.Core != nil {
+				cores = append(cores, info.Core)
+			}
+		}
+	}
+
+	if len(IDs) == 0 {
+		return nil, fmt.Errorf("annotation %s value invalid", ps.allocAnno)
+	}
+	ascendVisibleDevices := fmt.Sprintf("%d", IDs[0])
+	for i := 1; i < len(IDs); i++ {
+		ascendVisibleDevices = fmt.Sprintf("%s,%d", ascendVisibleDevices, IDs[i])
+	}
+	resp.Envs = make(map[string]string)
+	resp.Envs["ASCEND_VISIBLE_DEVICES"] = ascendVisibleDevices
+
+	vnpuMode := pod.Annotations[VNPUModeAnnotation]
+	klog.V(4).Infof("Pod %s vnpu mode: %s", pod.Name, vnpuMode)
+	if vnpuMode == VNPUModeHamiCore {
+		// 1. Handle volume mount injection
+		var mounts []*v1beta1.Mount
+		// A.Huawei driver and SMI toolchain (Read-Only)
+		driverPaths := []string{
+			"/usr/local/bin/npu-smi",
+			"/etc/ascend_install.info",
+			"/usr/local/Ascend/driver/lib64/driver",
+			"/usr/local/Ascend/driver/version.info",
+		}
+		for _, p := range driverPaths {
+			mounts = append(mounts, &v1beta1.Mount{HostPath: p, ContainerPath: p, ReadOnly: true})
+		}
+
+		mounts = append(mounts, &v1beta1.Mount{
+			HostPath:      "/usr/local/hami-vnpu-core",
+			ContainerPath: "/hami-vnpu-core",
+			ReadOnly:      true,
+		})
+		// B. Inject HAMi library path by mounting /etc/ld.so.preload.
+		mounts = append(mounts, &v1beta1.Mount{
+			HostPath:      "/usr/local/hami-vnpu-core/ld.so.preload", // Template file on host
+			ContainerPath: "/etc/ld.so.preload",                      // Overwrites the target file in container
+			ReadOnly:      true,
+		})
+
+		// C. Shared directory for HAMi compute resource partitioning (Read/Write)
+		mounts = append(mounts, &v1beta1.Mount{
+			HostPath:      "/usr/local/hami-shared-region",
+			ContainerPath: "/hami-shared-region",
+			ReadOnly:      false,
+		})
+		resp.Mounts = mounts
+
+		// Set NPU_MEM_QUOTA
+		if len(memories) > 0 && memories[0] != nil {
+			resp.Envs["NPU_MEM_QUOTA"] = strconv.FormatInt(*memories[0], 10)
+			klog.V(4).InfoS("Memory quota set", "value", *memories[0])
+		}
+
+		// Set NPU_PRIORITY
+		if len(cores) > 0 && cores[0] != nil {
+			resp.Envs["NPU_PRIORITY"] = strconv.FormatInt(int64(*cores[0]), 10)
+			klog.V(4).InfoS("Core priority set", "value", *cores[0])
+		}
+
+		// Set GLOBAL_SHM_PATH separated by device ID.
+		if len(IDs) > 0 {
+			resp.Envs["NPU_GLOBAL_SHM_PATH"] = fmt.Sprintf("/hami-shared-region/%d_global_registry", IDs[0])
+			klog.V(5).Infof("Create %d_global_registry", IDs[0])
+		} else {
+			klog.Warningf("No device IDs allocated")
+		}
+	} else {
+		if ascendVNPUSpec != "" {
+			resp.Envs["ASCEND_VNPU_SPECS"] = ascendVNPUSpec
+		}
+	}
+	return resp, nil
+}
+
+// getNextContainerDevices reads the toAllocDeviceAnno annotation and returns
+// the devices of the first container that still has pending allocations.
+func (ps *PluginServer) getNextContainerDevices(pod *v1.Pod) (device.ContainerDevices, error) {
+	anno, ok := pod.Annotations[ps.toAllocDeviceAnno]
+	if !ok {
+		return nil, fmt.Errorf("annotation %s not found", ps.toAllocDeviceAnno)
+	}
+	podSingleDev, err := decodePodSingleDevice(anno)
+	if err != nil {
+		return nil, fmt.Errorf("decode annotation %s: %w", ps.toAllocDeviceAnno, err)
+	}
+	for _, ctrDevice := range podSingleDev {
+		if len(ctrDevice) > 0 {
+			return ctrDevice, nil
+		}
+	}
+	return nil, fmt.Errorf("no pending device allocation in annotation %s", ps.toAllocDeviceAnno)
+}
+
+// buildTempLookup reads the allocAnno annotation and returns a map from
+// device UUID to its vNPU template name.
+func (ps *PluginServer) buildRuntimeInfoLookup(pod *v1.Pod) (map[string]RuntimeInfo, error) {
+	anno, ok := pod.Annotations[ps.allocAnno]
+	if !ok {
+		// The annotation may not exist for non-vNPU scenarios; return empty lookup.
+		return nil, fmt.Errorf("annotation %s not set", ps.allocAnno)
+	}
+	var rtInfo []RuntimeInfo
+	if err := json.Unmarshal([]byte(anno), &rtInfo); err != nil {
+		return nil, fmt.Errorf("annotation %s value %s invalid: %w", ps.allocAnno, anno, err)
+	}
+	lookup := make(map[string]RuntimeInfo, len(rtInfo))
+	for _, info := range rtInfo {
+		if info.UUID != "" {
+			lookup[info.UUID] = info
+		}
+	}
+	return lookup, nil
+}
+
+// eraseCurrentContainerAnnotation erases the current container's devices from
+// the toAllocDeviceAnno annotation, so the next Allocate call will advance
+// to the next container.
+func (ps *PluginServer) eraseCurrentContainerAnnotation(pod *v1.Pod) error {
+	anno, ok := pod.Annotations[ps.toAllocDeviceAnno]
+	if !ok {
+		return fmt.Errorf("annotation %s not found", ps.toAllocDeviceAnno)
+	}
+	podSingleDev, err := decodePodSingleDevice(anno)
+	if err != nil {
+		return fmt.Errorf("decode annotation %s: %w", ps.toAllocDeviceAnno, err)
+	}
+	res := make(device.PodSingleDevice, 0, len(podSingleDev))
+	found := false
+	for _, val := range podSingleDev {
+		if found {
+			res = append(res, val)
+		} else {
+			if len(val) > 0 {
+				found = true
+				res = append(res, device.ContainerDevices{})
+			} else {
+				res = append(res, val)
+			}
+		}
+	}
+	klog.V(5).Infof("After erase annotation, remaining devices: %v", res)
+	newAnnoValue := device.EncodePodSingleDevice(res)
+	newAnnos := map[string]string{
+		ps.toAllocDeviceAnno: newAnnoValue,
+	}
+	if err := util.PatchPodAnnotations(pod, newAnnos); err != nil {
+		return err
+	}
+	// Update in-memory pod annotations so subsequent getNextContainerDevices
+	// calls within the same Allocate see the erased state.
+	pod.Annotations[ps.toAllocDeviceAnno] = newAnnoValue
+	return nil
+}
+
+// decodePodSingleDevice decodes a single annotation value string into a
+// PodSingleDevice. It reuses HAMi's DecodeContainerDevices for per-device
+// parsing. The format is:
+//
+//	<ctr1-dev1>,<fields>:<ctr1-dev2>,<fields>;<ctr2-dev1>,<fields>;...
+func decodePodSingleDevice(str string) (device.PodSingleDevice, error) {
+	if len(str) == 0 {
+		return device.PodSingleDevice{}, nil
+	}
+	pd := make(device.PodSingleDevice, 0)
+	for _, s := range strings.Split(str, device.OnePodMultiContainerSplitSymbol) {
+		cd, err := device.DecodeContainerDevices(s)
+		if err != nil {
+			return nil, err
+		}
+		if len(cd) == 0 {
+			continue
+		}
+		pd = append(pd, cd)
+	}
+	return pd, nil
+}
+
 func (ps *PluginServer) parsePodAnnotation(pod *v1.Pod) ([]int32, []string, []*int64, []*int32, error) {
 	anno, ok := pod.Annotations[ps.allocAnno]
 	if !ok {
@@ -531,94 +749,37 @@ func (ps *PluginServer) Allocate(ctx context.Context, reqs *v1beta1.AllocateRequ
 		klog.Errorf("get pending pod error: %v", err)
 		return nil, fmt.Errorf("get pending pod error: %w", err)
 	}
-	resp := v1beta1.ContainerAllocateResponse{}
-	IDs, temps, memories, cores, err := ps.parsePodAnnotation(pod)
-	if err != nil {
-		return nil, fmt.Errorf("parse pod annotation error: %w", err)
+	klog.Infof("allocating for pod %s/%s", pod.Namespace, pod.Name)
+
+	responses := v1beta1.AllocateResponse{}
+
+	// resp := v1beta1.ContainerAllocateResponse{}
+	for _, req := range reqs.ContainerRequests {
+		containerDevs, err := ps.getNextContainerDevices(pod)
+		if err != nil {
+			return nil, fmt.Errorf("get next container devices: %w", err)
+		}
+		klog.Infof("containerDevs: %+v", containerDevs)
+
+		if len(containerDevs) != len(req.DevicesIDs) {
+			return nil, fmt.Errorf("device number not matched: annotation has %d, request has %d", len(containerDevs), len(req.DevicesIDs))
+		}
+
+		resp, err := ps.buildContainerAllocateResponse(pod, containerDevs)
+		if err != nil {
+			return nil, fmt.Errorf("build container allocate response: %w", err)
+		}
+
+		if err := ps.eraseCurrentContainerAnnotation(pod); err != nil {
+			klog.Errorf("erase current container annotation error: %v", err)
+			return nil, fmt.Errorf("erase current container annotation: %w", err)
+		}
+
+		responses.ContainerResponses = append(responses.ContainerResponses, resp)
 	}
-
-	vnpuMode := pod.Annotations[VNPUModeAnnotation]
-	klog.V(4).Infof("Pod %s vnpu mode: %s", pod.Name, vnpuMode)
-
-	if len(IDs) == 0 {
-		return nil, fmt.Errorf("empty id from pod annotation")
-	}
-	ascendVisibleDevices := fmt.Sprintf("%d", IDs[0])
-	for i := 1; i < len(IDs); i++ {
-		ascendVisibleDevices = fmt.Sprintf("%s,%d", ascendVisibleDevices, IDs[i])
-	}
-
-	resp.Envs = make(map[string]string)
-	resp.Envs["ASCEND_VISIBLE_DEVICES"] = ascendVisibleDevices
-
-	if vnpuMode == VNPUModeHamiCore {
-		// 1. Handle volume mount injection
-		var mounts []*v1beta1.Mount
-		// A.Huawei driver and SMI toolchain (Read-Only)
-		driverPaths := []string{
-			"/usr/local/bin/npu-smi",
-			"/etc/ascend_install.info",
-			"/usr/local/Ascend/driver/lib64/driver",
-			"/usr/local/Ascend/driver/version.info",
-		}
-		for _, p := range driverPaths {
-			mounts = append(mounts, &v1beta1.Mount{HostPath: p, ContainerPath: p, ReadOnly: true})
-		}
-
-		mounts = append(mounts, &v1beta1.Mount{
-			HostPath:      "/usr/local/hami-vnpu-core",
-			ContainerPath: "/hami-vnpu-core",
-			ReadOnly:      true,
-		})
-		// B. Inject HAMi library path by mounting /etc/ld.so.preload.
-		mounts = append(mounts, &v1beta1.Mount{
-			HostPath:      "/usr/local/hami-vnpu-core/ld.so.preload", // Template file on host
-			ContainerPath: "/etc/ld.so.preload",                      // Overwrites the target file in container
-			ReadOnly:      true,
-		})
-
-		// C. Shared directory for HAMi compute resource partitioning (Read/Write)
-		mounts = append(mounts, &v1beta1.Mount{
-			HostPath:      "/usr/local/hami-shared-region",
-			ContainerPath: "/hami-shared-region",
-			ReadOnly:      false,
-		})
-		resp.Mounts = mounts
-
-		// Set NPU_MEM_QUOTA
-		if len(memories) > 0 && memories[0] != nil {
-			resp.Envs["NPU_MEM_QUOTA"] = strconv.FormatInt(*memories[0], 10)
-			klog.V(4).InfoS("Memory quota set", "value", *memories[0])
-		}
-
-		// Set NPU_PRIORITY
-		if len(cores) > 0 && cores[0] != nil {
-			resp.Envs["NPU_PRIORITY"] = strconv.FormatInt(int64(*cores[0]), 10)
-			klog.V(4).InfoS("Core priority set", "value", *cores[0])
-		}
-
-		// Set GLOBAL_SHM_PATH separated by device ID.
-		if len(IDs) > 0 {
-			resp.Envs["NPU_GLOBAL_SHM_PATH"] = fmt.Sprintf("/hami-shared-region/%d_global_registry", IDs[0])
-			klog.V(5).Infof("Create %d_global_registry", IDs[0])
-		} else {
-			klog.Warningf("No device IDs allocated")
-		}
-	} else {
-		ascendVNPUSpec := ""
-		for i := 0; i < len(temps); i++ {
-			if temps[i] != "" {
-				ascendVNPUSpec = temps[i]
-				break
-			}
-		}
-		if ascendVNPUSpec != "" {
-			resp.Envs["ASCEND_VNPU_SPECS"] = ascendVNPUSpec
-		}
-	}
-	klog.V(5).Infof("allocate response: %v", resp)
+	klog.V(5).Infof("allocate response: %+v", responses.ContainerResponses)
 	success = true
-	return &v1beta1.AllocateResponse{ContainerResponses: []*v1beta1.ContainerAllocateResponse{&resp}}, nil
+	return &responses, nil
 }
 
 func (ps *PluginServer) PreStartContainer(context.Context, *v1beta1.PreStartContainerRequest) (*v1beta1.PreStartContainerResponse, error) {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -18,6 +18,8 @@ package server
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"flag"
 	"fmt"
@@ -25,25 +27,22 @@ import (
 	"net"
 	"os"
 	"path"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
 
-	"github.com/Project-HAMi/HAMi/pkg/device"
-
-	// "github.com/Project-HAMi/HAMi/pkg/device/ascend"
-	"crypto/sha256"
-	"encoding/hex"
-	"path/filepath"
-
-	"github.com/Project-HAMi/HAMi/pkg/util"
-	"github.com/Project-HAMi/HAMi/pkg/util/nodelock"
-	"github.com/Project-HAMi/ascend-device-plugin/internal/manager"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/klog/v2"
 	"k8s.io/kubelet/pkg/apis/deviceplugin/v1beta1"
+
+	// "github.com/Project-HAMi/HAMi/pkg/device/ascend"
+	"github.com/Project-HAMi/HAMi/pkg/device"
+	"github.com/Project-HAMi/HAMi/pkg/device-plugin/nvidiadevice/nvinternal/plugin"
+	"github.com/Project-HAMi/HAMi/pkg/util"
+	"github.com/Project-HAMi/ascend-device-plugin/internal/manager"
 )
 
 const (
@@ -62,6 +61,7 @@ var (
 )
 
 type PluginServer struct {
+	commonWord            string
 	nodeName              string
 	registerAnno          string
 	handshakeAnno         string
@@ -84,7 +84,8 @@ type RuntimeInfo struct {
 
 func NewPluginServer(mgr *manager.AscendManager, nodeName string, checkIdleVNPUInterval int) (*PluginServer, error) {
 	commonWord := mgr.CommonWord()
-	return &PluginServer{
+	server := &PluginServer{
+		commonWord:            commonWord,
 		nodeName:              nodeName,
 		registerAnno:          fmt.Sprintf("hami.io/node-register-%s", commonWord),
 		handshakeAnno:         fmt.Sprintf("hami.io/node-handshake-%s", commonWord),
@@ -96,7 +97,10 @@ func NewPluginServer(mgr *manager.AscendManager, nodeName string, checkIdleVNPUI
 		stopCh:                make(chan interface{}),
 		healthCh:              make(chan int32),
 		checkIdleVNPUInterval: checkIdleVNPUInterval,
-	}, nil
+	}
+	// enable calling hami methods
+	device.InRequestDevices[commonWord] = server.toAllocDeviceAnno
+	return server, nil
 }
 
 // fileSHA256 calculates the SHA256 checksum of the specified file
@@ -739,22 +743,25 @@ func (ps *PluginServer) Allocate(ctx context.Context, reqs *v1beta1.AllocateRequ
 	success := false
 	var pod *v1.Pod
 	defer func() {
-		lockerr := nodelock.ReleaseNodeLock(ps.nodeName, NodeLockAscend, pod, success)
-		if lockerr != nil {
-			klog.Errorf("failed to release lock:%s", lockerr.Error())
+		if pod == nil {
+			return
+		}
+		if success {
+			ps.podAllocationTrySuccess(pod)
+		} else {
+			ps.podAllocationFailed(pod)
 		}
 	}()
-	pod, err := util.GetPendingPod(ctx, ps.nodeName)
-	if err != nil {
-		klog.Errorf("get pending pod error: %v", err)
-		return nil, fmt.Errorf("get pending pod error: %w", err)
-	}
-	klog.Infof("allocating for pod %s/%s", pod.Namespace, pod.Name)
 
 	responses := v1beta1.AllocateResponse{}
-
-	// resp := v1beta1.ContainerAllocateResponse{}
 	for _, req := range reqs.ContainerRequests {
+		pod, err := util.GetPendingPod(ctx, ps.nodeName)
+		if err != nil {
+			klog.Errorf("get pending pod error: %v", err)
+			return nil, fmt.Errorf("get pending pod error: %w", err)
+		}
+		klog.Infof("allocating for pod %s/%s", pod.Namespace, pod.Name)
+
 		containerDevs, err := ps.getNextContainerDevices(pod)
 		if err != nil {
 			return nil, fmt.Errorf("get next container devices: %w", err)
@@ -784,4 +791,17 @@ func (ps *PluginServer) Allocate(ctx context.Context, reqs *v1beta1.AllocateRequ
 
 func (ps *PluginServer) PreStartContainer(context.Context, *v1beta1.PreStartContainerRequest) (*v1beta1.PreStartContainerResponse, error) {
 	return &v1beta1.PreStartContainerResponse{}, nil
+}
+
+// podAllocationTrySuccess checks if all containers of this pod have been
+// allocated. If so, it sets bind-phase to "success" and releases the node
+// lock; otherwise it returns without setting bind-phase or releasing the lock,
+// waiting for the next Allocate call.
+func (ps *PluginServer) podAllocationTrySuccess(pod *v1.Pod) {
+	plugin.PodAllocationTrySuccess(ps.nodeName, ps.commonWord, NodeLockAscend, pod)
+}
+
+// podAllocationFailed sets bind-phase to "failed" and releases the node lock.
+func (ps *PluginServer) podAllocationFailed(pod *v1.Pod) {
+	plugin.PodAllocationFailed(ps.nodeName, pod, NodeLockAscend)
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -21,6 +21,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
 	"io"
@@ -30,6 +31,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"syscall"
 	"time"
 
 	"google.golang.org/grpc"
@@ -168,7 +170,7 @@ func prepareHostResources() error {
 		}
 
 		if err := copyFile(srcPath, destPath); err != nil {
-			if strings.Contains(err.Error(), "text file busy") {
+			if errors.Is(err, syscall.ETXTBSY) {
 				klog.Warningf("⚠ %s is in use by running process, keeping existing version (safe)", destPath)
 				continue
 			}

--- a/internal/vnpu.go
+++ b/internal/vnpu.go
@@ -63,7 +63,6 @@ func LoadConfig(path string) (*Config, error) {
 	return &yamlData, nil
 }
 
-
 type NodeConfig struct {
 	Name         string `json:"name"`
 	HamiVnpuCore bool   `json:"hami-vnpu-core"`


### PR DESCRIPTION
What type of PR is this?
  
/kind bug

What this PR does / why we need it:

This PR improves error handling across the manager and server packages:

1. Wrap bare errors with context — `NewAscendManager`, `LoadConfig`, `serve`, and `registerKubelet` now return wrapped errors with descriptive messages instead of propagating bare errors, making it easier to trace failure origins in logs and debugging.
2. Use `%w` instead of `%v` in `fmt.Errorf` — `CleanupIdleVNPUs` used %v which breaks the error chain; switching to %w preserves it so `errors.Is/errors.As` unwrapping works correctly.
3. Use `errors.Is` instead of string matching for `ETXTBSY` — `prepareHostResources` previously checked `strings.Contains(err.Error(), "text file busy")`, which is fragile and locale-dependent. Replaced with `errors.Is(err, syscall.ETXTBSY)` for correctness.
4. Add error logging in `GetIDs` and `GetUnHealthIDs` — These methods silently swallowed errors; now they log the failure before returning nil or continuing.


Special notes for your reviewer:

No behavioral changes — the same error paths are hit, just with better messages and correct wrapping. The ETXTBSY check is functionally equivalent but more robust.

Does this PR introduce a user-facing change?:

NONE