### PR TITLE
fix: create ascend device plugin log path

### DIFF
--- a/ascend-device-plugin.yaml
+++ b/ascend-device-plugin.yaml
@@ -111,7 +111,7 @@ spec:
         - name: log-path
           hostPath:
             path: /var/log/mindx-dl/devicePlugin
-            type: Directory
+            type: DirectoryOrCreate
         - name: tmp
           hostPath:
             path: /tmp


### PR DESCRIPTION
close #89 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the device plugin configuration so the log directory is created automatically if it doesn’t already exist, reducing startup issues on fresh systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->