### PR TITLE
fix: correct register cores for HamiVnpuCore mode

### DIFF
--- a/internal/server/register.go
+++ b/internal/server/register.go
@@ -70,12 +70,16 @@ func (ps *PluginServer) registerHAMi() error {
 	apiDevices := make([]*device.DeviceInfo, 0, len(devs))
 	// hami currently believes that the index starts from 0 and is continuous.
 	for i, dev := range devs {
+		devcore := dev.AICore
+		if ps.mgr.IsHamiVnpuCore() {
+			devcore = HamiVnpuCoreMaxPercent
+		}
 		device := &device.DeviceInfo{
 			Index:   uint(i),
 			ID:      dev.UUID,
 			Count:   int32(ps.mgr.VDeviceCount()),
 			Devmem:  int32(dev.Memory),
-			Devcore: dev.AICore,
+			Devcore: devcore,
 			Type:    ps.mgr.CommonWord(),
 			Numa:    0,
 			Health:  dev.Health,

--- a/internal/server/register_test.go
+++ b/internal/server/register_test.go
@@ -388,6 +388,42 @@ func TestRegisterHAMi(t *testing.T) {
 			},
 		},
 		{
+			name: "IsHamiVnpuCore_Devcore100",
+			args: registerHAMiArgs{
+				nodeName:      "test-node",
+				registerAnno:  "hami.io/node-register-Ascend310P",
+				handshakeAnno: "hami.io/node-handshake-Ascend310P",
+				mgr: &FakeManager{
+					GetDevicesFunc: func() []*manager.Device {
+						return []*manager.Device{
+							{UUID: "uuid1", Memory: 21527, AICore: 8, Health: true},
+						}
+					},
+					VDeviceCountFunc:   func() int { return 1 },
+					CommonWordFunc:     func() string { return "Ascend310P" },
+					IsHamiVnpuCoreFunc: func() bool { return true },
+				},
+				nodes: []*v1.Node{
+					{ObjectMeta: metav1.ObjectMeta{Name: "test-node", Annotations: map[string]string{}}},
+				},
+			},
+			want: registerHAMiWant{
+				deviceCount: 1,
+				deviceCheck: func(t *testing.T, devs []*device.DeviceInfo) {
+					t.Helper()
+					if devs[0].Devcore != HamiVnpuCoreMaxPercent {
+						t.Fatalf("device Devcore = %d, want %d in hami-vnpu-core mode", devs[0].Devcore, HamiVnpuCoreMaxPercent)
+					}
+				},
+				annotationCheck: func(t *testing.T, annos map[string]string) {
+					t.Helper()
+					if annos[VNPUNodeSelectorAnnotation] != "true" {
+						t.Fatalf("VNPUNodeSelectorAnnotation = %q, want 'true'", annos[VNPUNodeSelectorAnnotation])
+					}
+				},
+			},
+		},
+		{
 			name: "IsHamiVnpuCore_False",
 			args: registerHAMiArgs{
 				nodeName:      "test-node",

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -46,6 +46,9 @@ const (
 	VNPUModeAnnotation         = "huawei.com/vnpu-mode"
 	VNPUModeHamiCore           = "hami-core"
 	VNPUNodeSelectorAnnotation = "hami-vnpu-core"
+	// HamiVnpuCoreMaxPercent is the total allocatable core units per device in
+	// soft-slice (hami-vnpu-core) mode, where core requests are percentages.
+	HamiVnpuCoreMaxPercent = 100
 )
 
 var (


### PR DESCRIPTION
Currently, the register annotation always register cores according to device preset. However, the vNPU core mod assume one device have 100 cores. 

Although the scheduler has handled this inconsistency. It still effects the metrics thus it will be limit 8 and allocated 100.
This pr aims to correct this inconsistency. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Devices in the special core-allocation mode now report a full 100% allocatable core value.
  * Core allocation displayed to users remains consistent across supported device types in this mode.

* **Bug Fixes**
  * Corrected device registration so core capacity is set appropriately instead of using the standard device core value in the special mode.

* **Tests**
  * Added coverage for the updated core-allocation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->