### PR TITLE
Fix registration error when setup

### DIFF
--- a/internal/server/register.go
+++ b/internal/server/register.go
@@ -174,11 +174,20 @@ func (ps *PluginServer) dial(unixSocketPath string, timeout time.Duration) (*grp
 		return nil, fmt.Errorf("grpc.NewClient(%s): %w", target, err)
 	}
 
-	// NewClient is non-blocking; block here to match the original WithBlock behaviour.
-	if !c.WaitForStateChange(ctx, connectivity.Idle) {
-		c.Close()
-		return nil, fmt.Errorf("timed out waiting for connection to %s", unixSocketPath)
+	c.Connect()
+	for {
+		state := c.GetState()
+		if state == connectivity.Ready {
+			return c, nil
+		}
+		if state == connectivity.TransientFailure || state == connectivity.Shutdown {
+			c.Close()
+			return nil, fmt.Errorf("connection to %s failed (state: %s)", unixSocketPath, state)
+		}
+		// Block until the state changes or the deadline is exceeded.
+		if !c.WaitForStateChange(ctx, state) {
+			c.Close()
+			return nil, fmt.Errorf("timed out waiting for connection to %s", unixSocketPath)
+		}
 	}
-
-	return c, nil
 }

--- a/internal/server/register.go
+++ b/internal/server/register.go
@@ -161,18 +161,23 @@ func (ps *PluginServer) dial(unixSocketPath string, timeout time.Duration) (*grp
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
-	c, _ := grpc.NewClient(unixSocketPath,
+
+	target := "passthrough:///" + unixSocketPath
+	c, err := grpc.NewClient(target,
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
 		grpc.WithContextDialer(func(ctx2 context.Context, addr string) (net.Conn, error) {
 			var d net.Dialer
 			return d.DialContext(ctx2, "unix", addr)
 		}),
 	)
+	if err != nil {
+		return nil, fmt.Errorf("grpc.NewClient(%s): %w", target, err)
+	}
 
 	// NewClient is non-blocking; block here to match the original WithBlock behaviour.
-	if !c.WaitForStateChange(ctx, connectivity.Ready) {
+	if !c.WaitForStateChange(ctx, connectivity.Idle) {
 		c.Close()
-		return nil, ctx.Err()
+		return nil, fmt.Errorf("timed out waiting for connection to %s", unixSocketPath)
 	}
 
 	return c, nil


### PR DESCRIPTION
Add prefix 'passthrough:///' to avoid connection error

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved local plugin connections over Unix sockets by creating the underlying gRPC client with a passthrough target derived from the socket path.
  * Plugin startup now reports connection-creation failures instead of silently ignoring them.
  * Connection readiness is handled more robustly: the system waits until the connection is ready, fails fast on transient/shutdown states, and returns a clearer timeout error (instead of a generic context timeout).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->