### PR TITLE
feat(monitor): start embedded vNPU metrics server and report per-device utilization

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,38 @@ spec:
            huawei.com/Ascend310P-memory: "4096"
 ```
 
+## Monitoring
+
+When a node runs in **hami-vnpu-core (soft slicing) mode**, the device plugin starts an **embedded Prometheus exporter** on **`:9395/metrics`** that reports physical-device and per-container vNPU usage. It is **not** started for the legacy template-based vNPU (or whole-card) path, which has no soft-slice data to export. The DaemonSet declares the `monitorport` (9395) container port; the metrics `Service` and `ServiceMonitor` ship in `ascend-vnpu-monitor-integration.yaml`.
+
+### Exposed metrics
+
+| Metric | Labels | Description |
+| :--- | :--- | :--- |
+| `hami_host_gpu_memory_used_bytes` | `device_index`, `device_uuid`, `device_type` | Physical NPU memory used (bytes) |
+| `hami_host_gpu_utilization_ratio` | `device_index`, `device_uuid`, `device_type` | Physical NPU AICore utilization (0–100) |
+| `hami_vgpu_memory_used_bytes` | `namespace`, `pod`, `container`, `vdevice_index`, `device_uuid` | Per-container vNPU memory used (bytes) |
+| `hami_vgpu_memory_limit_bytes` | `namespace`, `pod`, `container`, `vdevice_index`, `device_uuid` | Per-container vNPU memory limit (bytes) |
+| `hami_container_device_utilization_ratio` | `namespace`, `pod`, `container`, `vdevice_index`, `device_uuid` | AICore utilization of the device the container runs on (0–100) |
+
+Per-container metrics come from the `hami-vnpu-core` soft-slice shmem and require the Pod to carry the device-UUID annotation the plugin writes (`huawei.com/Ascend<type>`), i.e. workloads soft-sliced through this plugin. In soft-slice mode multiple containers share one physical card, so they report that card's AICore utilization.
+
+### Scrape with Prometheus
+
+Quick check via `port-forward` to a plugin Pod:
+
+```bash
+POD=$(kubectl -n kube-system get pod -l app.kubernetes.io/component=hami-ascend-device-plugin -o jsonpath='{.items[0].metadata.name}')
+kubectl -n kube-system port-forward "$POD" 9395:9395
+curl -s localhost:9395/metrics | grep hami_
+```
+
+With the Prometheus Operator (kube-prometheus-stack) installed, apply the metrics `Service`, `ServiceMonitor` and recording rules:
+
+```bash
+kubectl apply -f https://raw.githubusercontent.com/Project-HAMi/ascend-device-plugin/main/ascend-vnpu-monitor-integration.yaml
+```
+
 ## License
 
 [![FOSSA Status](https://app.fossa.com/api/projects/git%2Bgithub.com%2FProject-HAMi%2Fascend-device-plugin.svg?type=large)](https://app.fossa.com/projects/git%2Bgithub.com%2FProject-HAMi%2Fascend-device-plugin?ref=badge_large)

--- a/README_cn.md
+++ b/README_cn.md
@@ -200,3 +200,35 @@ spec:
           huawei.com/Ascend310P: "1"
           huawei.com/Ascend310P-memory: "4096"
 ```
+
+## 监控
+
+当节点运行在 **hami-vnpu-core(软切)模式**时,设备插件会在 **`:9395/metrics`** 启动内置 **Prometheus exporter**,上报物理设备级和每容器的 vNPU 使用指标。传统的模板 vNPU(或整卡)模式**不会**启动它——那种模式没有软切数据可导出。DaemonSet 声明了 `monitorport`(9395)容器端口;metrics `Service` 和 `ServiceMonitor` 放在 `ascend-vnpu-monitor-integration.yaml` 里。
+
+### 暴露的指标
+
+| 指标 | 标签 | 说明 |
+| :--- | :--- | :--- |
+| `hami_host_gpu_memory_used_bytes` | `device_index`, `device_uuid`, `device_type` | 物理 NPU 已用显存(字节) |
+| `hami_host_gpu_utilization_ratio` | `device_index`, `device_uuid`, `device_type` | 物理 NPU AICore 利用率(0–100) |
+| `hami_vgpu_memory_used_bytes` | `namespace`, `pod`, `container`, `vdevice_index`, `device_uuid` | 每容器 vNPU 已用显存(字节) |
+| `hami_vgpu_memory_limit_bytes` | `namespace`, `pod`, `container`, `vdevice_index`, `device_uuid` | 每容器 vNPU 显存上限(字节) |
+| `hami_container_device_utilization_ratio` | `namespace`, `pod`, `container`, `vdevice_index`, `device_uuid` | 容器所在设备的 AICore 利用率(0–100) |
+
+每容器指标来自 `hami-vnpu-core` 软切的共享内存,依赖插件写入的设备 UUID 注解(`huawei.com/Ascend<型号>`),即通过本插件软切的负载。软切模式下多个容器共享同一张物理卡,因此它们上报的是该卡的 AICore 利用率。
+
+### 用 Prometheus 抓取
+
+通过 `port-forward` 到插件 Pod 快速验证:
+
+```bash
+POD=$(kubectl -n kube-system get pod -l app.kubernetes.io/component=hami-ascend-device-plugin -o jsonpath='{.items[0].metadata.name}')
+kubectl -n kube-system port-forward "$POD" 9395:9395
+curl -s localhost:9395/metrics | grep hami_
+```
+
+已安装 Prometheus Operator(kube-prometheus-stack)时,应用 metrics `Service`、`ServiceMonitor` 和录制规则:
+
+```bash
+kubectl apply -f https://raw.githubusercontent.com/Project-HAMi/ascend-device-plugin/main/ascend-vnpu-monitor-integration.yaml
+```

--- a/ascend-device-plugin.yaml
+++ b/ascend-device-plugin.yaml
@@ -66,6 +66,11 @@ spec:
           args:
             - --config_file
             - /device-config.yaml
+          ports:
+            # Embedded vNPU Prometheus metrics endpoint (/metrics).
+            - name: monitorport
+              containerPort: 9395
+              protocol: TCP
           securityContext:
             privileged: true
             readOnlyRootFilesystem: false

--- a/ascend-vnpu-monitor-integration.yaml
+++ b/ascend-vnpu-monitor-integration.yaml
@@ -1,6 +1,26 @@
-# Prometheus integration for embedded vNPU monitor (:9395/metrics).
+# Prometheus integration for the embedded vNPU monitor (:9395/metrics), which the
+# device-plugin serves only in hami-vnpu-core (soft-slice) mode.
 # Apply when kube-prometheus-stack (or compatible Prometheus Operator) is installed.
 # Kantaloupe discovers ServiceMonitors labeled release=prometheus in monitoring namespace.
+---
+# Headless Service exposing the plugin's vNPU metrics endpoint; the ServiceMonitor
+# below selects it by label.
+apiVersion: v1
+kind: Service
+metadata:
+  name: hami-ascend-device-plugin-metrics
+  namespace: kube-system
+  labels:
+    app.kubernetes.io/component: hami-ascend-device-plugin
+spec:
+  clusterIP: None
+  selector:
+    app.kubernetes.io/component: hami-ascend-device-plugin
+  ports:
+    - name: monitorport
+      port: 9395
+      targetPort: monitorport
+      protocol: TCP
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -25,6 +25,7 @@ import (
 	"github.com/Project-HAMi/HAMi/pkg/util/client"
 	"github.com/Project-HAMi/ascend-device-plugin/internal"
 	"github.com/Project-HAMi/ascend-device-plugin/internal/manager"
+	"github.com/Project-HAMi/ascend-device-plugin/internal/monitor"
 	"github.com/Project-HAMi/ascend-device-plugin/internal/server"
 	"github.com/Project-HAMi/ascend-device-plugin/version"
 	"github.com/fsnotify/fsnotify"
@@ -148,6 +149,19 @@ func main() {
 		klog.Fatalf("init PluginServer failed, error is %v", err)
 	}
 	client.InitGlobalClient()
+
+	if mgr.IsHamiVnpuCore() {
+		go func() {
+			defer func() {
+				if r := recover(); r != nil {
+					klog.Errorf("recovered from panic in vNPU metrics server: %v", r)
+				}
+			}()
+			monitor.StartMetricsServer(":9395", "/usr/local/hami-vnpu-core/containers")
+		}()
+	} else {
+		klog.Info("hami-vnpu-core disabled on this node; not starting the vNPU metrics server")
+	}
 
 	if err = start(server); err != nil {
 		klog.Fatalf("start PluginServer failed, error is %v", err)

--- a/internal/monitor/collector.go
+++ b/internal/monitor/collector.go
@@ -93,8 +93,8 @@ func (c *vNPUCollector) Collect(ch chan<- prometheus.Metric) {
 		klog.Errorf("Host device stats: %v", err)
 	}
 
-	c.collectPodMetrics(ch, hostDevices)
-	c.collectHostMetrics(ch, hostDevices)
+	podMemByDevice := c.collectPodMetrics(ch, hostDevices)
+	c.collectHostMetrics(ch, hostDevices, podMemByDevice)
 }
 
 func formatDeviceType(deviceType string) string {
@@ -104,9 +104,13 @@ func formatDeviceType(deviceType string) string {
 	return "Ascend-" + deviceType
 }
 
-func (c *vNPUCollector) collectHostMetrics(ch chan<- prometheus.Metric, devices []DeviceStat) {
+func (c *vNPUCollector) collectHostMetrics(ch chan<- prometheus.Metric, devices []DeviceStat, podMemByDevice map[string]uint64) {
 	for _, d := range devices {
 		hostUsed := float64(d.MemoryUsed) * 1024 * 1024
+		// Override with pod aggregate if available (more accurate in device-share mode)
+		if sum, ok := podMemByDevice[d.UUID]; ok && sum > 0 {
+			hostUsed = float64(sum)
+		}
 		labels := []string{fmt.Sprint(d.Index), d.UUID, formatDeviceType(d.DeviceType)}
 		ch <- prometheus.MustNewConstMetric(hostGPUdesc, prometheus.GaugeValue, hostUsed, labels...)
 		ch <- prometheus.MustNewConstMetric(hostGPUUtilizationdesc, prometheus.GaugeValue, float64(d.AICorePct), labels...)
@@ -120,9 +124,9 @@ func (c *vNPUCollector) collectPodMetrics(ch chan<- prometheus.Metric, devices [
 		return nil
 	}
 
-	hostAICore := 0.0
-	if len(devices) > 0 {
-		hostAICore = float64(devices[0].AICorePct)
+	utilByUUID := make(map[string]float64)
+	for _, d := range devices {
+		utilByUUID[d.UUID] = float64(d.AICorePct)
 	}
 
 	podMemByDevice := make(map[string]uint64)
@@ -153,7 +157,7 @@ func (c *vNPUCollector) collectPodMetrics(ch chan<- prometheus.Metric, devices [
 
 			ch <- prometheus.MustNewConstMetric(ctrvGPUdesc, prometheus.GaugeValue, float64(memoryUsed), baseLabels...)
 			ch <- prometheus.MustNewConstMetric(ctrvGPUlimitdesc, prometheus.GaugeValue, float64(memoryLimit), baseLabels...)
-			ch <- prometheus.MustNewConstMetric(ctrDeviceUtilizationdesc, prometheus.GaugeValue, hostAICore, baseLabels...)
+			ch <- prometheus.MustNewConstMetric(ctrDeviceUtilizationdesc, prometheus.GaugeValue, utilByUUID[devUUID], baseLabels...)
 			ch <- prometheus.MustNewConstMetric(ctrDeviceMemoryContextDesc, prometheus.GaugeValue, float64(memoryContextSize), baseLabels...)
 			ch <- prometheus.MustNewConstMetric(ctrDeviceMemoryModuleDesc, prometheus.GaugeValue, float64(memoryModuleSize), baseLabels...)
 			ch <- prometheus.MustNewConstMetric(ctrDeviceMemoryBufferDesc, prometheus.GaugeValue, float64(memoryBufferSize), baseLabels...)

--- a/internal/monitor/container.go
+++ b/internal/monitor/container.go
@@ -98,6 +98,26 @@ func (l *ContainerLister) Stop() {
 	close(l.stopCh)
 }
 
+// ascendDeviceResource returns the Ascend device resource the container requests
+// (also the pod-annotation key holding its device UUIDs), or "" if there is none.
+func ascendDeviceResource(pod *corev1.Pod, ctrName string) string {
+	for _, c := range pod.Spec.Containers {
+		if c.Name != ctrName {
+			continue
+		}
+		for _, rl := range []corev1.ResourceList{c.Resources.Limits, c.Resources.Requests} {
+			for res := range rl {
+				k := string(res)
+				if strings.HasPrefix(k, "huawei.com/Ascend") &&
+					!strings.HasSuffix(k, "-core") && !strings.HasSuffix(k, "-memory") {
+					return k
+				}
+			}
+		}
+	}
+	return ""
+}
+
 // ListContainers enumerates container directories and reads shmem from each.
 // Directory format: {podUID}_{containerName}.
 func (l *ContainerLister) ListContainers() ([]ContainerEntry, error) {
@@ -155,12 +175,14 @@ func (l *ContainerLister) ListContainers() ([]ContainerEntry, error) {
 		}
 
 		var devUUIDs []string
-		if anno, ok := pod.Annotations["huawei.com/Ascend310P"]; ok {
-			var devs []struct{ UUID string }
-			if json.Unmarshal([]byte(anno), &devs) == nil {
-				for _, d := range devs {
-					if d.UUID != "" {
-						devUUIDs = append(devUUIDs, d.UUID)
+		if key := ascendDeviceResource(pod, ctrName); key != "" {
+			if anno, ok := pod.Annotations[key]; ok {
+				var devs []struct{ UUID string }
+				if json.Unmarshal([]byte(anno), &devs) == nil {
+					for _, d := range devs {
+						if d.UUID != "" {
+							devUUIDs = append(devUUIDs, d.UUID)
+						}
 					}
 				}
 			}


### PR DESCRIPTION
## What

The device-plugin ships an embedded vNPU Prometheus monitor (`internal/monitor`, `:9395/metrics`) but it was never started, so `/metrics` served nothing. This PR starts it and fixes the per-device utilization metric.

## Changes

- **`cmd/main.go`** — start `monitor.StartMetricsServer(":9395", "/usr/local/hami-vnpu-core/containers")` in a goroutine, so the embedded monitor actually runs. It runs in its own goroutine so the collector's informer cache sync can't delay device-plugin registration with the kubelet.
- **`internal/monitor/collector.go`**
  - `hami_container_device_utilization_ratio` now uses each container's device UUID → AICore% (previously it always used `devices[0]`, so it reported 0 whenever a workload ran on a card other than the first).
  - `hami_host_gpu_memory_used_bytes` is overridden by the sum of per-container used memory on that device, which is more accurate under device sharing.

## Testing

Deployed on an Atlas 300I Pro (310P) node and cross-checked `:9395/metrics` against `npu-smi info` with live vNPU workloads on two pods:
- `hami_vgpu_memory_used_bytes` matched each container's per-process device memory.
- `hami_container_device_utilization_ratio` matched the device AICore%.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an embedded Prometheus metrics endpoint that starts automatically (port **9395**), including Kubernetes Service support for scraping.
* **Bug Fixes**
  * Improved device-level memory reporting so host memory reflects aggregated per-device pod usage.
  * Fixed per-container utilization to use the correct per-device utilization values.
  * Improved container device UUID matching by deriving the Ascend resource key from requested/limited resources.
* **Documentation**
  * Documented the monitoring endpoint and metric categories (including per-container soft-slice metrics) in English and Chinese.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->