### PR TITLE
feat(device-share): auto-enable device-share

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,25 @@ This project implements  a soft slicing mechanism based on `libvnpu.so` intercep
 hami-vnpu-core Soft Slicing Requirements:
 
 - **Ascend Driver Version**: ≥ 25.5
-- **Chip Mode**: enable `device-share` mode on Ascend chips for virtualization
-Below is the English translation of the instructions for enabling `device-share` mode:
+- **Chip Mode**: `device-share` is **auto-managed at the node level**. When the
+  node is configured for hami-vnpu-core soft slicing (the `hami-vnpu-core` field
+  in `device-node-config`), the device plugin enables device-share on **every
+  chip on the node at startup**, running
+  `npu-smi set -t device-share -i <card> -c <chip> -d 1` once per chip. No manual
+  `npu-smi` step and no per-Pod annotation are required to enable it.
+
+  The plugin resolves `npu-smi` from, in order:
+  `/usr/local/Ascend/driver/tools/npu-smi` (provided by the existing driver
+  hostPath mount), `/usr/local/sbin/npu-smi`, `/usr/local/bin/npu-smi`, then
+  `PATH`. If your host ships `npu-smi` elsewhere, add a single-file hostPath
+  mount in `ascend-device-plugin.yaml`, e.g. `/usr/local/sbin/npu-smi`.
+
+  This config is read once at startup, so **changing `hami-vnpu-core` requires
+  restarting the plugin** to take effect. If any chip's flip fails, the **plugin
+  fails to start** and advertises no devices on the node until it succeeds.
+
+<details>
+<summary>Legacy: manually enabling <code>device-share</code> (no longer required)</summary>
 
 **Enabling `device-share` Mode**
 
@@ -37,6 +54,8 @@ Below is the English translation of the instructions for enabling `device-share`
 | :--- | :--- |
 | *id* | **Device ID**. The NPU ID found by running the **npu-smi info -l** command is the device ID. |
 | *value* | **Container Enable Status**: Options are disabled or enabled. The default is disabled.<br>0: Disabled<br>1: Enabled |
+
+</details>
 
 ## Compile
 

--- a/README_cn.md
+++ b/README_cn.md
@@ -22,7 +22,14 @@ Ascend device plugin 是用来支持在 [HAMi](https://github.com/Project-HAMi/H
 **hami-vnpu-core 软切分要求：**
 
 - Ascend 驱动版本：≥ 25.5
-- 芯片模式：在昇腾芯片上开启 `device-share` 模式以支持虚拟化。
+- 芯片模式：`device-share` 现在由插件在**节点级自动管理**。当节点被配置为 hami-vnpu-core 软切分（`device-node-config` 中的 `hami-vnpu-core` 字段）时，插件在**启动阶段对节点上的每块芯片**开启 device-share，逐芯片执行一次 `npu-smi set -t device-share -i <card> -c <chip> -d 1`，无需手动执行 `npu-smi`，也无需在 Pod 上加注解来开启。
+
+  插件按以下顺序解析 `npu-smi`：`/usr/local/Ascend/driver/tools/npu-smi`（由已有的 driver hostPath 挂载提供）、`/usr/local/sbin/npu-smi`、`/usr/local/bin/npu-smi`，最后是 `PATH`。若宿主机的 `npu-smi` 在其他位置，可在 `ascend-device-plugin.yaml` 中增加单文件 hostPath 挂载（例如 `/usr/local/sbin/npu-smi`）。
+
+  该配置仅在启动时读取一次，因此**修改 `hami-vnpu-core` 需重启插件**才能生效。若任一芯片翻转失败，**插件将启动失败**，在成功之前不会上报该节点的设备。
+
+<details>
+<summary>历史：手动开启 <code>device-share</code>（已不再需要）</summary>
 
 **开启 `device-share` 模式**
 
@@ -34,6 +41,8 @@ Ascend device plugin 是用来支持在 [HAMi](https://github.com/Project-HAMi/H
 | ------- | ----------------------------------------------------------- |
 | *id*    | 设备 ID。通过 **npu-smi info -l** 命令查出的 NPU ID 即为设备 ID。 |
 | *value* | 容器使能状态：分为禁用、使能。默认禁用。<br>0：禁用<br>1：使能 |
+
+</details>
 
 ## 编译
 

--- a/internal/server/device_share.go
+++ b/internal/server/device_share.go
@@ -1,0 +1,142 @@
+/*
+ * Copyright 2024 The HAMi Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package server
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+
+	"k8s.io/klog/v2"
+)
+
+// chipKey identifies a single NPU chip by the two coordinates npu-smi takes
+// for its -i (card) and -c (chip) flags.
+type chipKey struct {
+	Card int32
+	Chip int32
+}
+
+// npuSmiCandidates lists the host paths where npu-smi may live, in priority
+// order. The first is what the daemonset's /usr/local/Ascend/driver hostPath
+// mount exposes; the others cover hosts that ship npu-smi elsewhere. It is a
+// package var so tests can point it at a temp dir.
+var npuSmiCandidates = []string{
+	"/usr/local/Ascend/driver/tools/npu-smi",
+	"/usr/local/sbin/npu-smi",
+	"/usr/local/bin/npu-smi",
+}
+
+// runNpuSmi executes npu-smi with the given args and returns combined output.
+// It is a package var so tests can substitute a fake.
+//
+// Enabling device-share (-d 1) prints a "There are security risks ... continue
+// setting?(Y/N)" prompt and aborts with exit 200 if stdin is closed. npu-smi
+// has no -y/--force flag in the driver versions this plugin targets, so we
+// feed "Y\n" unconditionally: commands that don't prompt simply ignore the
+// unread stdin.
+var runNpuSmi = func(args ...string) ([]byte, error) {
+	bin, err := resolveNpuSmi()
+	if err != nil {
+		return nil, err
+	}
+	cmd := exec.Command(bin, args...)
+	cmd.Stdin = strings.NewReader("Y\n")
+	return cmd.CombinedOutput()
+}
+
+func resolveNpuSmi() (string, error) {
+	for _, p := range npuSmiCandidates {
+		st, err := os.Stat(p)
+		if err == nil && !st.IsDir() && st.Mode()&0111 != 0 {
+			return p, nil
+		}
+	}
+	if p, err := exec.LookPath("npu-smi"); err == nil {
+		return p, nil
+	}
+	return "", fmt.Errorf("npu-smi not found in %v or PATH", npuSmiCandidates)
+}
+
+// applyDeviceShare flips device-share on every chip in chips. It does not query
+// current state first — npu-smi accepts redundant set commands, so the
+// unconditional write is cheaper than a query+set round trip and keeps Allocate
+// latency predictable.
+//
+// Fails fast on the first per-chip error. The caller (Allocate) propagates that
+// error so kubelet surfaces it on the Pod; partial state on the remaining chips
+// will be re-driven by the next Allocate that lands on them.
+//
+// This plugin only ever calls it with enabled=true; the enabled=false path
+// exists for symmetry and test coverage.
+func applyDeviceShare(chips []chipKey, enabled bool) error {
+	if len(chips) == 0 {
+		return nil
+	}
+	flag := "0"
+	if enabled {
+		flag = "1"
+	}
+	for _, c := range chips {
+		card := strconv.Itoa(int(c.Card))
+		chip := strconv.Itoa(int(c.Chip))
+		out, err := runNpuSmi("set", "-t", "device-share", "-i", card, "-c", chip, "-d", flag)
+		if err != nil {
+			return fmt.Errorf("npu-smi set device-share -i %s -c %s -d %s: %w: %s",
+				card, chip, flag, err, strings.TrimSpace(string(out)))
+		}
+		klog.V(4).Infof("device-share card=%s chip=%s set to %s", card, chip, flag)
+	}
+	return nil
+}
+
+// enableNodeDeviceShare turns device-share on for every chip on the node when
+// the node is configured for hami-vnpu-core soft slicing. It is called once at
+// startup (from Start, after UpdateDevice has populated the device list) and is
+// idempotent: npu-smi accepts redundant set commands, so a plugin restart
+// simply re-applies the same state.
+//
+// When the node is not hami-vnpu-core it is a no-op — it never writes -d 0, so
+// share state set for other purposes is left untouched.
+//
+// Fail-fast: any per-chip failure is returned to the caller, which aborts
+// startup so kubelet restarts the plugin and retries.
+func (ps *PluginServer) enableNodeDeviceShare() error {
+	if !ps.mgr.IsHamiVnpuCore() {
+		klog.V(3).Infof("node %s is not hami-vnpu-core, skipping device-share", ps.nodeName)
+		return nil
+	}
+	chipSet := map[chipKey]struct{}{}
+	for _, d := range ps.mgr.GetDevices() {
+		chipSet[chipKey{Card: d.CardID, Chip: d.DeviceID}] = struct{}{}
+	}
+	if len(chipSet) == 0 {
+		klog.Warningf("node %s is hami-vnpu-core but no devices found for device-share", ps.nodeName)
+		return nil
+	}
+	chips := make([]chipKey, 0, len(chipSet))
+	for c := range chipSet {
+		chips = append(chips, c)
+	}
+	if err := applyDeviceShare(chips, true); err != nil {
+		return fmt.Errorf("enable node device-share: %w", err)
+	}
+	klog.Infof("device-share enabled on %d chip(s) of node %s", len(chips), ps.nodeName)
+	return nil
+}

--- a/internal/server/device_share.go
+++ b/internal/server/device_share.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The HAMi Authors.
+ * Copyright 2026 The HAMi Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,31 +26,26 @@ import (
 	"k8s.io/klog/v2"
 )
 
-// chipKey identifies a single NPU chip by the two coordinates npu-smi takes
-// for its -i (card) and -c (chip) flags.
+// chipKey identifies an NPU chip by npu-smi's -i (card) and -c (chip) coordinates.
 type chipKey struct {
 	Card int32
 	Chip int32
 }
 
-// npuSmiCandidates lists the host paths where npu-smi may live, in priority
-// order. The first is what the daemonset's /usr/local/Ascend/driver hostPath
-// mount exposes; the others cover hosts that ship npu-smi elsewhere. It is a
-// package var so tests can point it at a temp dir.
+// npuSmiCandidates lists host paths where npu-smi may live, in priority order.
+// A package var so tests can point it at a temp dir.
 var npuSmiCandidates = []string{
 	"/usr/local/Ascend/driver/tools/npu-smi",
 	"/usr/local/sbin/npu-smi",
 	"/usr/local/bin/npu-smi",
 }
 
-// runNpuSmi executes npu-smi with the given args and returns combined output.
-// It is a package var so tests can substitute a fake.
+// runNpuSmi runs npu-smi and returns combined output. A package var so tests
+// can substitute a fake.
 //
-// Enabling device-share (-d 1) prints a "There are security risks ... continue
-// setting?(Y/N)" prompt and aborts with exit 200 if stdin is closed. npu-smi
-// has no -y/--force flag in the driver versions this plugin targets, so we
-// feed "Y\n" unconditionally: commands that don't prompt simply ignore the
-// unread stdin.
+// Enabling device-share (-d 1) prompts "continue setting?(Y/N)" and exits 200
+// if stdin is closed; npu-smi has no -y flag, so we feed "Y\n" unconditionally
+// (commands that don't prompt ignore the unread stdin).
 var runNpuSmi = func(args ...string) ([]byte, error) {
 	bin, err := resolveNpuSmi()
 	if err != nil {
@@ -74,17 +69,10 @@ func resolveNpuSmi() (string, error) {
 	return "", fmt.Errorf("npu-smi not found in %v or PATH", npuSmiCandidates)
 }
 
-// applyDeviceShare flips device-share on every chip in chips. It does not query
-// current state first — npu-smi accepts redundant set commands, so the
-// unconditional write is cheaper than a query+set round trip and keeps Allocate
-// latency predictable.
-//
-// Fails fast on the first per-chip error. The caller (Allocate) propagates that
-// error so kubelet surfaces it on the Pod; partial state on the remaining chips
-// will be re-driven by the next Allocate that lands on them.
-//
-// This plugin only ever calls it with enabled=true; the enabled=false path
-// exists for symmetry and test coverage.
+// applyDeviceShare sets device-share on every chip unconditionally; npu-smi
+// accepts redundant set commands, so this is cheaper than a query+set round
+// trip. Fails fast on the first per-chip error, leaving later chips to be
+// re-driven by the next Allocate. The enabled=false path exists only for tests.
 func applyDeviceShare(chips []chipKey, enabled bool) error {
 	if len(chips) == 0 {
 		return nil
@@ -107,16 +95,10 @@ func applyDeviceShare(chips []chipKey, enabled bool) error {
 }
 
 // enableNodeDeviceShare turns device-share on for every chip on the node when
-// the node is configured for hami-vnpu-core soft slicing. It is called once at
-// startup (from Start, after UpdateDevice has populated the device list) and is
-// idempotent: npu-smi accepts redundant set commands, so a plugin restart
-// simply re-applies the same state.
-//
-// When the node is not hami-vnpu-core it is a no-op — it never writes -d 0, so
-// share state set for other purposes is left untouched.
-//
-// Fail-fast: any per-chip failure is returned to the caller, which aborts
-// startup so kubelet restarts the plugin and retries.
+// it runs in hami-vnpu-core soft-slice mode. Called once at startup and
+// idempotent (npu-smi accepts redundant set commands). On a non-hami-vnpu-core
+// node it is a no-op and never writes -d 0. Any per-chip failure aborts startup
+// so kubelet restarts and retries.
 func (ps *PluginServer) enableNodeDeviceShare() error {
 	if !ps.mgr.IsHamiVnpuCore() {
 		klog.V(3).Infof("node %s is not hami-vnpu-core, skipping device-share", ps.nodeName)

--- a/internal/server/device_share_test.go
+++ b/internal/server/device_share_test.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The HAMi Authors.
+ * Copyright 2026 The HAMi Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,8 +27,8 @@ import (
 	"github.com/Project-HAMi/ascend-device-plugin/internal/manager"
 )
 
-// withFakeNpuSmi swaps the package-level runNpuSmi for a fake and restores it
-// after the test. Shared by the Allocate device-share tests in server_test.go.
+// withFakeNpuSmi swaps runNpuSmi for a fake and restores it after the test.
+// Shared with the Allocate device-share tests in server_test.go.
 func withFakeNpuSmi(t *testing.T, fn func(args ...string) ([]byte, error)) {
 	t.Helper()
 	orig := runNpuSmi
@@ -86,10 +86,8 @@ func TestApplyDeviceShare_Disable(t *testing.T) {
 	}
 }
 
-// TestApplyDeviceShare_FailFast guards the contract that the first per-chip
-// failure stops the loop — Allocate cannot return a partial response, so any
-// chip past the failure point must be left untouched and re-driven by the
-// next Allocate.
+// TestApplyDeviceShare_FailFast checks that the first per-chip failure stops
+// the loop, leaving later chips untouched.
 func TestApplyDeviceShare_FailFast(t *testing.T) {
 	var calls [][]string
 	withFakeNpuSmi(t, func(args ...string) ([]byte, error) {
@@ -127,11 +125,8 @@ func TestApplyDeviceShare_NoChips(t *testing.T) {
 	}
 }
 
-// TestRunNpuSmi_AnswersDeviceShareConfirmation guards the production runNpuSmi
-// path: enabling device-share triggers npu-smi's interactive Y/N prompt and
-// the binary exits 200 if stdin is closed. The fake here mimics that prompt
-// and only succeeds when "Y" is delivered on stdin, so the test exercises the
-// real exec.Command wiring (not the runNpuSmi mock used elsewhere).
+// TestRunNpuSmi_AnswersDeviceShareConfirmation exercises the real exec.Command
+// path: the fake npu-smi prompts Y/N and exits 200 unless "Y" arrives on stdin.
 func TestRunNpuSmi_AnswersDeviceShareConfirmation(t *testing.T) {
 	dir := t.TempDir()
 	fake := filepath.Join(dir, "npu-smi")

--- a/internal/server/device_share_test.go
+++ b/internal/server/device_share_test.go
@@ -1,0 +1,239 @@
+/*
+ * Copyright 2024 The HAMi Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package server
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/Project-HAMi/ascend-device-plugin/internal/manager"
+)
+
+// withFakeNpuSmi swaps the package-level runNpuSmi for a fake and restores it
+// after the test. Shared by the Allocate device-share tests in server_test.go.
+func withFakeNpuSmi(t *testing.T, fn func(args ...string) ([]byte, error)) {
+	t.Helper()
+	orig := runNpuSmi
+	runNpuSmi = fn
+	t.Cleanup(func() { runNpuSmi = orig })
+}
+
+func sampleChips() []chipKey {
+	return []chipKey{
+		{Card: 0, Chip: 0},
+		{Card: 0, Chip: 1},
+		{Card: 1, Chip: 0},
+	}
+}
+
+func TestApplyDeviceShare_Enable(t *testing.T) {
+	var calls [][]string
+	withFakeNpuSmi(t, func(args ...string) ([]byte, error) {
+		calls = append(calls, append([]string(nil), args...))
+		return nil, nil
+	})
+
+	if err := applyDeviceShare(sampleChips(), true); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	want := [][]string{
+		{"set", "-t", "device-share", "-i", "0", "-c", "0", "-d", "1"},
+		{"set", "-t", "device-share", "-i", "0", "-c", "1", "-d", "1"},
+		{"set", "-t", "device-share", "-i", "1", "-c", "0", "-d", "1"},
+	}
+	if !reflect.DeepEqual(calls, want) {
+		t.Fatalf("calls mismatch:\ngot  %v\nwant %v", calls, want)
+	}
+}
+
+func TestApplyDeviceShare_Disable(t *testing.T) {
+	var calls [][]string
+	withFakeNpuSmi(t, func(args ...string) ([]byte, error) {
+		calls = append(calls, append([]string(nil), args...))
+		return nil, nil
+	})
+
+	if err := applyDeviceShare(sampleChips(), false); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	want := [][]string{
+		{"set", "-t", "device-share", "-i", "0", "-c", "0", "-d", "0"},
+		{"set", "-t", "device-share", "-i", "0", "-c", "1", "-d", "0"},
+		{"set", "-t", "device-share", "-i", "1", "-c", "0", "-d", "0"},
+	}
+	if !reflect.DeepEqual(calls, want) {
+		t.Fatalf("calls mismatch:\ngot  %v\nwant %v", calls, want)
+	}
+}
+
+// TestApplyDeviceShare_FailFast guards the contract that the first per-chip
+// failure stops the loop — Allocate cannot return a partial response, so any
+// chip past the failure point must be left untouched and re-driven by the
+// next Allocate.
+func TestApplyDeviceShare_FailFast(t *testing.T) {
+	var calls [][]string
+	withFakeNpuSmi(t, func(args ...string) ([]byte, error) {
+		calls = append(calls, append([]string(nil), args...))
+		// Fail on card=0 chip=1 (the second call).
+		if len(args) >= 7 && args[4] == "0" && args[6] == "1" {
+			return []byte("E80001 not allowed"), fmt.Errorf("exit status 1")
+		}
+		return nil, nil
+	})
+
+	err := applyDeviceShare(sampleChips(), true)
+	if err == nil {
+		t.Fatal("expected error from per-chip failure, got nil")
+	}
+	if !strings.Contains(err.Error(), "-i 0") || !strings.Contains(err.Error(), "-c 1") {
+		t.Fatalf("error should identify failing chip via npu-smi flags, got: %v", err)
+	}
+	if got := len(calls); got != 2 {
+		t.Fatalf("expected loop to stop after first failure (2 calls), got %d: %v", got, calls)
+	}
+}
+
+func TestApplyDeviceShare_NoChips(t *testing.T) {
+	called := false
+	withFakeNpuSmi(t, func(args ...string) ([]byte, error) {
+		called = true
+		return nil, nil
+	})
+	if err := applyDeviceShare(nil, true); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if called {
+		t.Fatal("npu-smi should not be invoked when chip list is empty")
+	}
+}
+
+// TestRunNpuSmi_AnswersDeviceShareConfirmation guards the production runNpuSmi
+// path: enabling device-share triggers npu-smi's interactive Y/N prompt and
+// the binary exits 200 if stdin is closed. The fake here mimics that prompt
+// and only succeeds when "Y" is delivered on stdin, so the test exercises the
+// real exec.Command wiring (not the runNpuSmi mock used elsewhere).
+func TestRunNpuSmi_AnswersDeviceShareConfirmation(t *testing.T) {
+	dir := t.TempDir()
+	fake := filepath.Join(dir, "npu-smi")
+	script := "#!/bin/sh\n" +
+		"echo 'There are security risks when opening device sharing,'\n" +
+		"echo 'Are you sure you want to continue setting?(Y/N)'\n" +
+		"read ans\n" +
+		"[ \"$ans\" = \"Y\" ] || exit 200\n" +
+		"echo ok\n"
+	if err := os.WriteFile(fake, []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake npu-smi: %v", err)
+	}
+
+	saved := npuSmiCandidates
+	npuSmiCandidates = []string{fake}
+	t.Cleanup(func() { npuSmiCandidates = saved })
+
+	out, err := runNpuSmi("set", "-t", "device-share", "-i", "0", "-c", "0", "-d", "1")
+	if err != nil {
+		t.Fatalf("expected success after Y answer, got err=%v out=%q", err, out)
+	}
+	if !strings.Contains(string(out), "ok") {
+		t.Fatalf("expected confirmation to be consumed and command to print ok, got %q", out)
+	}
+}
+
+func TestEnableNodeDeviceShare_NotHamiVnpuCore(t *testing.T) {
+	called := false
+	withFakeNpuSmi(t, func(args ...string) ([]byte, error) {
+		called = true
+		return nil, nil
+	})
+	ps := &PluginServer{
+		nodeName: "node-1",
+		mgr: &FakeManager{
+			IsHamiVnpuCoreFunc: func() bool { return false },
+			GetDevicesFunc: func() []*manager.Device {
+				return []*manager.Device{{CardID: 0, DeviceID: 0}}
+			},
+		},
+	}
+	if err := ps.enableNodeDeviceShare(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if called {
+		t.Fatal("npu-smi must not be invoked when node is not hami-vnpu-core")
+	}
+}
+
+func TestEnableNodeDeviceShare_FlipsAllChipsDeduped(t *testing.T) {
+	type ic struct{ card, chip string }
+	seen := map[ic]int{}
+	withFakeNpuSmi(t, func(args ...string) ([]byte, error) {
+		// args: set -t device-share -i <card> -c <chip> -d <flag>
+		if len(args) != 9 || args[8] != "1" {
+			t.Errorf("unexpected npu-smi args: %v", args)
+			return nil, nil
+		}
+		seen[ic{args[4], args[6]}]++
+		return nil, nil
+	})
+	ps := &PluginServer{
+		nodeName: "node-1",
+		mgr: &FakeManager{
+			IsHamiVnpuCoreFunc: func() bool { return true },
+			GetDevicesFunc: func() []*manager.Device {
+				return []*manager.Device{
+					{CardID: 0, DeviceID: 0},
+					{CardID: 0, DeviceID: 1},
+					{CardID: 0, DeviceID: 0}, // duplicate chip — must be flipped once
+					{CardID: 1, DeviceID: 0},
+				}
+			},
+		},
+	}
+	if err := ps.enableNodeDeviceShare(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := map[ic]int{
+		{"0", "0"}: 1,
+		{"0", "1"}: 1,
+		{"1", "0"}: 1,
+	}
+	if !reflect.DeepEqual(seen, want) {
+		t.Fatalf("device-share calls mismatch:\ngot  %v\nwant %v", seen, want)
+	}
+}
+
+func TestEnableNodeDeviceShare_FlipFailureFailsFast(t *testing.T) {
+	withFakeNpuSmi(t, func(args ...string) ([]byte, error) {
+		return []byte("E80001 not allowed"), fmt.Errorf("exit status 1")
+	})
+	ps := &PluginServer{
+		nodeName: "node-1",
+		mgr: &FakeManager{
+			IsHamiVnpuCoreFunc: func() bool { return true },
+			GetDevicesFunc: func() []*manager.Device {
+				return []*manager.Device{{CardID: 0, DeviceID: 0}}
+			},
+		},
+	}
+	if err := ps.enableNodeDeviceShare(); err == nil {
+		t.Fatal("expected error when npu-smi flip fails, got nil")
+	}
+}

--- a/internal/server/register.go
+++ b/internal/server/register.go
@@ -34,8 +34,9 @@ import (
 	"github.com/Project-HAMi/HAMi/pkg/util"
 )
 
+// watchAndRegister must be launched with ps.wg.Add(1) already called by the
+// caller (see Start()); doing the Add here would race with Stop()'s wg.Wait().
 func (ps *PluginServer) watchAndRegister() {
-	ps.wg.Add(1)
 	defer ps.wg.Done()
 	timer := time.After(1 * time.Second)
 	for {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -126,6 +126,9 @@ func (ps *PluginServer) Start() error {
 	if err != nil {
 		return err
 	}
+	if err := ps.enableNodeDeviceShare(); err != nil {
+		return err
+	}
 	err = ps.serve()
 	if err != nil {
 		return err

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -137,13 +137,18 @@ func (ps *PluginServer) Start() error {
 	if err != nil {
 		return err
 	}
+	// Add to the WaitGroup synchronously before launching the goroutines.
+	// sync.WaitGroup requires a positive Add (from a zero counter) to
+	// happen-before Wait; doing Add inside the goroutine races with Stop()'s
+	// Wait and panics with "WaitGroup is reused before previous Wait has returned".
+	ps.wg.Add(1)
 	go ps.startPeriodicCheckIdleVNPUs()
+	ps.wg.Add(1)
 	go ps.watchAndRegister()
 	return nil
 }
 
 func (ps *PluginServer) startPeriodicCheckIdleVNPUs() {
-	ps.wg.Add(1)
 	defer ps.wg.Done()
 	ticker := time.NewTicker(time.Duration(ps.checkIdleVNPUInterval) * time.Second)
 	defer ticker.Stop()


### PR DESCRIPTION
Auto-enable device-share at the node level instead of a manual per-chip npu-smi step. Fix #94 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatically enables NPU device-sharing (`device-share`) on every chip at startup in the supported `hami-vnpu-core` soft-slicing mode.
* **Bug Fixes**
  * Startup now aborts before serving/registration if enabling `device-share` fails for any chip; chip selection is deduplicated.
* **Documentation**
  * Updated README (EN/中文) with auto behavior, `npu-smi` lookup guidance, restart expectations, and legacy manual steps in a collapsible section.
* **Tests**
  * Added coverage for enable/disable, deduplication, fail-fast behavior, `npu-smi` confirmation input, and skipping in non-soft-slicing mode.
* **Refactor**
  * Improved goroutine startup ordering to avoid a WaitGroup race during stop.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->