### PR TITLE
charts: add ascend device plugin helm chart

### DIFF
--- a/charts/ascend-device-plugin/Chart.yaml
+++ b/charts/ascend-device-plugin/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: ascend-device-plugin
+description: HAMi Ascend device plugin
+type: application
+version: 0.1.0
+appVersion: v1.3.0

--- a/charts/ascend-device-plugin/README.md
+++ b/charts/ascend-device-plugin/README.md
@@ -39,6 +39,17 @@ helm install ascend-device-plugin ./charts/ascend-device-plugin \
 
 With this mode, the chart mounts the existing device config and still manages `hami-device-node-config` by default.
 
+## hami-vnpu-core
+
+Enable the global `vnpus.hamiVnpuCore` switch in the generated device config:
+
+```bash
+helm install ascend-device-plugin ./charts/ascend-device-plugin \
+  --namespace kube-system \
+  --set image.tag=v1.3.0 \
+  --set hamiVnpuCore.enabled=true
+```
+
 ## Node Configuration
 
 Override `nodeConfig` to enable or customize `hami-vnpu-core` per node:

--- a/charts/ascend-device-plugin/README.md
+++ b/charts/ascend-device-plugin/README.md
@@ -1,0 +1,52 @@
+# Ascend Device Plugin Helm Chart
+
+This chart deploys the standalone HAMi Ascend device plugin manifests:
+
+- RuntimeClass
+- ConfigMaps
+- RBAC and ServiceAccount
+- Device plugin DaemonSet
+
+## Install
+
+Label Ascend nodes before installing:
+
+```bash
+kubectl label node <ascend-node> ascend=on --overwrite
+```
+
+Install the chart:
+
+```bash
+helm install ascend-device-plugin ./charts/ascend-device-plugin \
+  --namespace kube-system \
+  --set image.tag=v1.3.0
+```
+
+If the HAMi chart already manages the Ascend device plugin DaemonSet, related ConfigMaps, RBAC, or RuntimeClass, do not deploy this standalone chart at the same time.
+
+## Existing Device Configuration
+
+If another chart, such as the HAMi chart, already owns the shared `hami-scheduler-device` ConfigMap, reuse it instead of creating another one:
+
+```bash
+helm install ascend-device-plugin ./charts/ascend-device-plugin \
+  --namespace kube-system \
+  --set image.tag=v1.3.0 \
+  --set config.create=false \
+  --set config.existingDeviceConfigMapName=hami-scheduler-device
+```
+
+With this mode, the chart mounts the existing device config and still manages `hami-device-node-config` by default.
+
+## Node Configuration
+
+Override `nodeConfig` to enable or customize `hami-vnpu-core` per node:
+
+```yaml
+nodeConfig: |-
+  nodes:
+    - name: "ascend-node-1"
+      hami-vnpu-core: true
+      vDeviceCount: 8
+```

--- a/charts/ascend-device-plugin/templates/_helpers.tpl
+++ b/charts/ascend-device-plugin/templates/_helpers.tpl
@@ -22,6 +22,19 @@
 {{- printf "%s:%s" .Values.image.repository (default .Chart.AppVersion .Values.image.tag) -}}
 {{- end -}}
 
+{{- define "ascend-device-plugin.selectorLabels" -}}
+app.kubernetes.io/component: hami-ascend-device-plugin
+app.kubernetes.io/name: {{ include "ascend-device-plugin.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{- define "ascend-device-plugin.labels" -}}
+helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+{{ include "ascend-device-plugin.selectorLabels" . }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
 {{- define "ascend-device-plugin.serviceAccountName" -}}
 {{- if .Values.serviceAccount.create -}}
 {{- default (include "ascend-device-plugin.fullname" .) .Values.serviceAccount.name -}}

--- a/charts/ascend-device-plugin/templates/_helpers.tpl
+++ b/charts/ascend-device-plugin/templates/_helpers.tpl
@@ -1,0 +1,39 @@
+{{- define "ascend-device-plugin.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "ascend-device-plugin.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- include "ascend-device-plugin.name" . | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "ascend-device-plugin.daemonSetName" -}}
+{{- default (include "ascend-device-plugin.fullname" .) .Values.daemonSet.name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "ascend-device-plugin.rbacName" -}}
+{{- default (include "ascend-device-plugin.fullname" .) .Values.rbac.name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "ascend-device-plugin.image" -}}
+{{- printf "%s:%s" .Values.image.repository (default .Chart.AppVersion .Values.image.tag) -}}
+{{- end -}}
+
+{{- define "ascend-device-plugin.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+{{- default (include "ascend-device-plugin.fullname" .) .Values.serviceAccount.name -}}
+{{- else -}}
+{{- default "default" .Values.serviceAccount.name -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "ascend-device-plugin.deviceConfigMapName" -}}
+{{- default .Values.config.deviceConfigMapName .Values.config.existingDeviceConfigMapName -}}
+{{- end -}}
+
+{{- define "ascend-device-plugin.nodeConfigMapName" -}}
+{{- default "hami-device-node-config" .Values.nodeConfigMap.name -}}
+{{- end -}}

--- a/charts/ascend-device-plugin/templates/configmap.yaml
+++ b/charts/ascend-device-plugin/templates/configmap.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: hami-ascend-device-plugin
 data:
   device-config.yaml: |-
-{{ .Values.deviceConfig | nindent 4 }}
+{{ tpl .Values.deviceConfig . | nindent 4 }}
 {{- end }}
 {{- if .Values.nodeConfigMap.create }}
 {{- if .Values.config.create }}

--- a/charts/ascend-device-plugin/templates/configmap.yaml
+++ b/charts/ascend-device-plugin/templates/configmap.yaml
@@ -5,12 +5,10 @@ metadata:
   name: {{ .Values.config.deviceConfigMapName }}
   namespace: {{ .Release.Namespace }}
   labels:
-    app.kubernetes.io/component: hami-ascend-device-plugin
-    app.kubernetes.io/name: hami-ascend-device-plugin
-    app.kubernetes.io/instance: hami-ascend-device-plugin
+{{- include "ascend-device-plugin.labels" . | nindent 4 }}
 data:
   device-config.yaml: |-
-{{ tpl .Values.deviceConfig . | nindent 4 }}
+{{- tpl .Values.deviceConfig . | nindent 4 }}
 {{- end }}
 {{- if .Values.nodeConfigMap.create }}
 {{- if .Values.config.create }}
@@ -22,10 +20,8 @@ metadata:
   name: {{ include "ascend-device-plugin.nodeConfigMapName" . }}
   namespace: {{ .Release.Namespace }}
   labels:
-    app.kubernetes.io/component: hami-ascend-device-plugin
-    app.kubernetes.io/name: hami-ascend-device-plugin
-    app.kubernetes.io/instance: hami-ascend-device-plugin
+{{- include "ascend-device-plugin.labels" . | nindent 4 }}
 data:
   node-config.yaml: |-
-{{ .Values.nodeConfig | nindent 4 }}
+{{- .Values.nodeConfig | nindent 4 }}
 {{- end }}

--- a/charts/ascend-device-plugin/templates/configmap.yaml
+++ b/charts/ascend-device-plugin/templates/configmap.yaml
@@ -1,0 +1,31 @@
+{{- if .Values.config.create }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Values.config.deviceConfigMapName }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/component: hami-ascend-device-plugin
+    app.kubernetes.io/name: hami-ascend-device-plugin
+    app.kubernetes.io/instance: hami-ascend-device-plugin
+data:
+  device-config.yaml: |-
+{{ .Values.deviceConfig | nindent 4 }}
+{{- end }}
+{{- if .Values.nodeConfigMap.create }}
+{{- if .Values.config.create }}
+---
+{{- end }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "ascend-device-plugin.nodeConfigMapName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/component: hami-ascend-device-plugin
+    app.kubernetes.io/name: hami-ascend-device-plugin
+    app.kubernetes.io/instance: hami-ascend-device-plugin
+data:
+  node-config.yaml: |-
+{{ .Values.nodeConfig | nindent 4 }}
+{{- end }}

--- a/charts/ascend-device-plugin/templates/daemonset.yaml
+++ b/charts/ascend-device-plugin/templates/daemonset.yaml
@@ -1,0 +1,96 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: {{ include "ascend-device-plugin.daemonSetName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/component: hami-ascend-device-plugin
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: hami-ascend-device-plugin
+      hami.io/webhook: ignore
+  template:
+    metadata:
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+      labels:
+        app.kubernetes.io/component: hami-ascend-device-plugin
+        hami.io/webhook: ignore
+    spec:
+      priorityClassName: system-node-critical
+      serviceAccountName: {{ include "ascend-device-plugin.serviceAccountName" . }}
+      containers:
+        - image: {{ include "ascend-device-plugin.image" . | quote }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          name: device-plugin
+          resources:
+{{ toYaml .Values.resources | nindent 12 }}
+          args:
+            - --config_file
+            - /device-config.yaml
+          securityContext:
+            privileged: true
+            readOnlyRootFilesystem: true
+          volumeMounts:
+            - name: device-plugin
+              mountPath: /var/lib/kubelet/device-plugins
+            - name: pod-resource
+              mountPath: /var/lib/kubelet/pod-resources
+            - name: hiai-driver
+              mountPath: /usr/local/Ascend/driver
+              readOnly: true
+            - name: log-path
+              mountPath: /var/log/mindx-dl/devicePlugin
+            - name: tmp
+              mountPath: /tmp
+            - name: hami-shared-region
+              mountPath: /usr/local/hami-shared-region
+            - name: hami-vnpu-core
+              mountPath: /usr/local/hami-vnpu-core
+            - name: ascend-config
+              mountPath: /device-config.yaml
+              subPath: device-config.yaml
+              readOnly: true
+            - name: ascend-node-config
+              mountPath: /node-config.yaml
+              subPath: node-config.yaml
+              readOnly: true
+          env:
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+      volumes:
+        - name: device-plugin
+          hostPath:
+            path: /var/lib/kubelet/device-plugins
+        - name: pod-resource
+          hostPath:
+            path: /var/lib/kubelet/pod-resources
+        - name: hiai-driver
+          hostPath:
+            path: /usr/local/Ascend/driver
+        - name: log-path
+          hostPath:
+            path: /var/log/mindx-dl/devicePlugin
+            type: DirectoryOrCreate
+        - name: tmp
+          hostPath:
+            path: /tmp
+        - name: hami-shared-region
+          hostPath:
+            path: /usr/local/hami-shared-region
+            type: DirectoryOrCreate
+        - name: hami-vnpu-core
+          hostPath:
+            path: /usr/local/hami-vnpu-core
+            type: DirectoryOrCreate
+        - name: ascend-config
+          configMap:
+            name: {{ include "ascend-device-plugin.deviceConfigMapName" . }}
+        - name: ascend-node-config
+          configMap:
+            name: {{ include "ascend-device-plugin.nodeConfigMapName" . }}
+      nodeSelector:
+{{ toYaml .Values.nodeSelector | nindent 8 }}

--- a/charts/ascend-device-plugin/templates/daemonset.yaml
+++ b/charts/ascend-device-plugin/templates/daemonset.yaml
@@ -4,18 +4,18 @@ metadata:
   name: {{ include "ascend-device-plugin.daemonSetName" . }}
   namespace: {{ .Release.Namespace }}
   labels:
-    app.kubernetes.io/component: hami-ascend-device-plugin
+{{- include "ascend-device-plugin.labels" . | nindent 4 }}
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/component: hami-ascend-device-plugin
+{{- include "ascend-device-plugin.selectorLabels" . | nindent 6 }}
       hami.io/webhook: ignore
   template:
     metadata:
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
       labels:
-        app.kubernetes.io/component: hami-ascend-device-plugin
+{{- include "ascend-device-plugin.labels" . | nindent 8 }}
         hami.io/webhook: ignore
     spec:
       priorityClassName: system-node-critical
@@ -29,9 +29,15 @@ spec:
           args:
             - --config_file
             - /device-config.yaml
+            - --node_config_file
+            - /node-config.yaml
+          ports:
+            - name: monitorport
+              containerPort: 9395
+              protocol: TCP
           securityContext:
             privileged: true
-            readOnlyRootFilesystem: true
+            readOnlyRootFilesystem: false
           volumeMounts:
             - name: device-plugin
               mountPath: /var/lib/kubelet/device-plugins
@@ -93,4 +99,4 @@ spec:
           configMap:
             name: {{ include "ascend-device-plugin.nodeConfigMapName" . }}
       nodeSelector:
-{{ toYaml .Values.nodeSelector | nindent 8 }}
+{{- toYaml .Values.nodeSelector | nindent 8 }}

--- a/charts/ascend-device-plugin/templates/rbac.yaml
+++ b/charts/ascend-device-plugin/templates/rbac.yaml
@@ -1,0 +1,34 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "ascend-device-plugin.rbacName" . }}
+rules:
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list", "update", "watch", "patch"]
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["get", "update", "patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "ascend-device-plugin.rbacName" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "ascend-device-plugin.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: {{ include "ascend-device-plugin.rbacName" . }}
+  apiGroup: rbac.authorization.k8s.io
+{{- if .Values.serviceAccount.create }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "ascend-device-plugin.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/component: hami-ascend
+{{- end }}

--- a/charts/ascend-device-plugin/templates/rbac.yaml
+++ b/charts/ascend-device-plugin/templates/rbac.yaml
@@ -2,6 +2,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: {{ include "ascend-device-plugin.rbacName" . }}
+  labels:
+{{- include "ascend-device-plugin.labels" . | nindent 4 }}
 rules:
   - apiGroups: [""]
     resources: ["pods"]
@@ -14,6 +16,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: {{ include "ascend-device-plugin.rbacName" . }}
+  labels:
+{{- include "ascend-device-plugin.labels" . | nindent 4 }}
 subjects:
   - kind: ServiceAccount
     name: {{ include "ascend-device-plugin.serviceAccountName" . }}
@@ -30,5 +34,5 @@ metadata:
   name: {{ include "ascend-device-plugin.serviceAccountName" . }}
   namespace: {{ .Release.Namespace }}
   labels:
-    app.kubernetes.io/component: hami-ascend
+{{- include "ascend-device-plugin.labels" . | nindent 4 }}
 {{- end }}

--- a/charts/ascend-device-plugin/templates/runtimeclass.yaml
+++ b/charts/ascend-device-plugin/templates/runtimeclass.yaml
@@ -1,0 +1,7 @@
+{{- if .Values.runtimeClass.create }}
+apiVersion: node.k8s.io/v1
+kind: RuntimeClass
+metadata:
+  name: {{ .Values.runtimeClass.name }}
+handler: {{ .Values.runtimeClass.handler }}
+{{- end }}

--- a/charts/ascend-device-plugin/templates/runtimeclass.yaml
+++ b/charts/ascend-device-plugin/templates/runtimeclass.yaml
@@ -3,5 +3,7 @@ apiVersion: node.k8s.io/v1
 kind: RuntimeClass
 metadata:
   name: {{ .Values.runtimeClass.name }}
+  labels:
+{{- include "ascend-device-plugin.labels" . | nindent 4 }}
 handler: {{ .Values.runtimeClass.handler }}
 {{- end }}

--- a/charts/ascend-device-plugin/values.yaml
+++ b/charts/ascend-device-plugin/values.yaml
@@ -1,0 +1,173 @@
+image:
+  repository: projecthami/ascend-device-plugin
+  tag: ""
+  pullPolicy: IfNotPresent
+
+nameOverride: ""
+fullnameOverride: ""
+
+daemonSet:
+  name: hami-ascend-device-plugin
+
+rbac:
+  name: hami-ascend
+
+runtimeClass:
+  create: true
+  name: ascend
+  handler: ascend
+
+serviceAccount:
+  create: true
+  name: hami-ascend
+
+nodeSelector:
+  ascend: "on"
+
+resources:
+  requests:
+    memory: 500Mi
+    cpu: 500m
+  limits:
+    memory: 500Mi
+    cpu: 500m
+
+config:
+  create: true
+  existingDeviceConfigMapName: ""
+  deviceConfigMapName: hami-scheduler-device
+
+nodeConfigMap:
+  create: true
+  name: hami-device-node-config
+
+deviceConfig: |-
+  vnpus:
+    hamiVnpuCore: false
+    configs:
+    - chipName: 910A
+      commonWord: Ascend910A
+      resourceName: huawei.com/Ascend910A
+      resourceMemoryName: huawei.com/Ascend910A-memory
+      memoryAllocatable: 32768
+      memoryCapacity: 32768
+      aiCore: 30
+      templates:
+        - name: vir02
+          memory: 2184
+          aiCore: 2
+        - name: vir04
+          memory: 4369
+          aiCore: 4
+        - name: vir08
+          memory: 8738
+          aiCore: 8
+        - name: vir16
+          memory: 17476
+          aiCore: 16
+    - chipName: 910B2
+      commonWord: Ascend910B2
+      resourceName: huawei.com/Ascend910B2
+      resourceMemoryName: huawei.com/Ascend910B2-memory
+      memoryAllocatable: 65536
+      memoryCapacity: 65536
+      aiCore: 24
+      aiCPU: 6
+      templates:
+        - name: vir03_1c_8g
+          memory: 8192
+          aiCore: 3
+          aiCPU: 1
+        - name: vir06_1c_16g
+          memory: 16384
+          aiCore: 6
+          aiCPU: 1
+        - name: vir12_3c_32g
+          memory: 32768
+          aiCore: 12
+          aiCPU: 3
+    - chipName: 910B3
+      commonWord: Ascend910B3
+      resourceName: huawei.com/Ascend910B3
+      resourceMemoryName: huawei.com/Ascend910B3-memory
+      resourceCoreName: huawei.com/Ascend910B3-core
+      memoryAllocatable: 65536
+      memoryCapacity: 65536
+      aiCore: 20
+      aiCPU: 7
+      templates:
+        - name: vir05_1c_16g
+          memory: 16384
+          aiCore: 5
+          aiCPU: 1
+        - name: vir10_3c_32g
+          memory: 32768
+          aiCore: 10
+          aiCPU: 3
+    - chipName: 910B4-1
+      commonWord: Ascend910B4-1
+      resourceName: huawei.com/Ascend910B4-1
+      resourceMemoryName: huawei.com/Ascend910B4-1-memory
+      memoryAllocatable: 65536
+      memoryCapacity: 65536
+      aiCore: 20
+      aiCPU: 7
+      templates:
+        - name: vir05_1c_16g
+          memory: 16384
+          aiCore: 5
+          aiCPU: 1
+        - name: vir10_3c_32g
+          memory: 32768
+          aiCore: 10
+          aiCPU: 3
+    - chipName: 910B4
+      commonWord: Ascend910B4
+      resourceName: huawei.com/Ascend910B4
+      resourceMemoryName: huawei.com/Ascend910B4-memory
+      memoryAllocatable: 32768
+      memoryCapacity: 32768
+      aiCore: 20
+      aiCPU: 7
+      templates:
+        - name: vir05_1c_8g
+          memory: 8192
+          aiCore: 5
+          aiCPU: 1
+        - name: vir10_3c_16g
+          memory: 16384
+          aiCore: 10
+          aiCPU: 3
+    - chipName: 310P3
+      commonWord: Ascend310P
+      resourceName: huawei.com/Ascend310P
+      resourceMemoryName: huawei.com/Ascend310P-memory
+      memoryAllocatable: 21527
+      memoryCapacity: 24576
+      aiCore: 8
+      aiCPU: 7
+      templates:
+        - name: vir01
+          memory: 3072
+          aiCore: 1
+          aiCPU: 1
+        - name: vir02
+          memory: 6144
+          aiCore: 2
+          aiCPU: 2
+        - name: vir04
+          memory: 12288
+          aiCore: 4
+          aiCPU: 4
+    - chipName: Ascend910
+      commonWord: Ascend910C
+      resourceName: huawei.com/Ascend910C
+      resourceMemoryName: huawei.com/Ascend910C-memory
+      resourceCoreName: huawei.com/Ascend910C-core
+      memoryAllocatable: 65536
+      memoryCapacity: 65536
+      aiCore: 20
+      aiCPU: 7
+
+nodeConfig: |-
+  nodes: []

--- a/charts/ascend-device-plugin/values.yaml
+++ b/charts/ascend-device-plugin/values.yaml
@@ -41,9 +41,12 @@ nodeConfigMap:
   create: true
   name: hami-device-node-config
 
+hamiVnpuCore:
+  enabled: false
+
 deviceConfig: |-
   vnpus:
-    hamiVnpuCore: false
+    hamiVnpuCore: {{ .Values.hamiVnpuCore.enabled }}
     configs:
     - chipName: 910A
       commonWord: Ascend910A


### PR DESCRIPTION
## Summary
- Add a standalone Helm chart for ascend-device-plugin under `charts/ascend-device-plugin`
- Template the DaemonSet, RBAC, ConfigMaps, and RuntimeClass from the existing manifests
- Document that this chart should not be installed together with another HAMi chart that manages the same Ascend device plugin resources

## Validation
- `helm lint charts/ascend-device-plugin`
- `helm template ascend-device-plugin charts/ascend-device-plugin --namespace kube-system`
- `ruby -e 'require "yaml"; YAML.load_stream(File.read("/tmp/ascend-device-plugin-chart-pr.yaml"))'`
- `git diff --check upstream/main...HEAD`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new Helm chart to deploy the Ascend Device Plugin, including an optional RuntimeClass, DaemonSet, RBAC, and service account.
  * Provides configurable defaults for image, resources, and node selection.
  * Ships device and node configuration via ConfigMaps (with the ability to reuse an existing device configuration ConfigMap).
  * Added values to enable/disable `vnpus.hamiVnpuCore` and customize per-node settings.
* **Documentation**
  * Added chart README with installation guidance, configuration options, and example nodeConfig snippet.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->