### PR TITLE
fix: stop staging the removed limiter binary onto the host

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,7 +90,6 @@ jobs:
     - name: Prepare artifacts for upload
       run: |
         mkdir -p ./artifacts
-        cp libvnpu/target/release/limiter ./artifacts/
         cp libvnpu/target/release/libvnpu.so ./artifacts/
         echo "/hami-vnpu-core/libvnpu.so" > ./artifacts/ld.so.preload
     - name: upload artifacts

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,5 @@ FROM $BASE_IMAGE
 ENV LD_LIBRARY_PATH=/usr/local/Ascend/driver/lib64:/usr/local/Ascend/driver/lib64/driver:/usr/local/Ascend/driver/lib64/common
 COPY --from=build /build/ascend-device-plugin /usr/local/bin/ascend-device-plugin
 COPY --from=build /build/lib/hami-vnpu-core/* /usr/local/hami-vnpu-core-assets/
-RUN chmod +x /usr/local/hami-vnpu-core-assets/limiter
 
 ENTRYPOINT ["ascend-device-plugin"]

--- a/internal/monitor/registry.go
+++ b/internal/monitor/registry.go
@@ -16,7 +16,7 @@ const (
 	localShmComputePrioOffset   = 16
 	localShmActiveWorkersOffset = 48
 
-	// ProcessSlot inside procs[] array
+	// ProcessSlot: pid@0, hbm_used[8]@8, is_active@72, size 80.
 	procSlotSize      = 80
 	procSlotPID       = 0
 	procSlotHBMOffset = 8 // [AtomicU64; NPU_DEVICE_MAX=8]

--- a/internal/server/util.go
+++ b/internal/server/util.go
@@ -45,7 +45,6 @@ func copyFile(src, dst string) error {
 		return err
 	}
 
-	// Sync source file permissions (ensure the limiter binary retains executable permission)
 	srcInfo, err := srcFile.Stat()
 	if err != nil {
 		return err
@@ -81,9 +80,7 @@ func prepareHostResources() error {
 		assetsDir = "/usr/local/hami-vnpu-core-assets"
 	}
 
-	// Define files to copy: source path in container -> target path on host
 	filesToCopy := map[string]string{
-		"limiter":       filepath.Join(targetDir, "limiter"),
 		"libvnpu.so":    filepath.Join(targetDir, "libvnpu.so"),
 		"ld.so.preload": filepath.Join(targetDir, "ld.so.preload"),
 	}


### PR DESCRIPTION
## What
The vNPU manager is now embedded as a background thread inside `libvnpu.so` (see Project-HAMi/hami-vnpu-core#11), so the standalone `limiter` binary no longer exists. This drops it from `prepareHostResources`' staging list — otherwise the device-plugin fails to start on the missing `/usr/local/hami-vnpu-core-assets/limiter` asset (`os.Open` error).

## Changes
- `internal/server/util.go`: remove `"limiter"` from `filesToCopy` (only `libvnpu.so` + `ld.so.preload` are staged now); generalize the copyFile permission comment.
- `internal/monitor/registry.go`: clarify the `ProcessSlot` layout comment (the Rust side now pins the byte layout with a compile-time assert).

## Testing (Ascend 310P)
Rebuilt + deployed the device-plugin: `prepareHostResources` stages `libvnpu.so` + `ld.so.preload` (no limiter), device-plugin starts cleanly, and the `:9395` monitor correctly tracks per-pod memory, process exit, and pod deletion.

Depends on Project-HAMi/hami-vnpu-core#11 (which removes the `limiter` binary).



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated host runtime staging and CI artifact publishing to include only the required staged support files, removing an extra binary from the upload set.
  * Adjusted the runtime image build to no longer explicitly set executable permissions for the removed asset.

* **Documentation**
  * Clarified shared-memory `ProcessSlot` layout with explicit byte offsets and total slot size.
  * Refined comments around permission synchronization to reflect preserved executable/library permission bits from staged assets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
