### PR TITLE
fix(manifest): pass --node_config_file so per-node config is actually loaded

### DIFF
--- a/ascend-device-plugin.yaml
+++ b/ascend-device-plugin.yaml
@@ -66,6 +66,8 @@ spec:
           args:
             - --config_file
             - /device-config.yaml
+            - --node_config_file
+            - /node-config.yaml
           ports:
             # Embedded vNPU Prometheus metrics endpoint (/metrics).
             - name: monitorport


### PR DESCRIPTION
## What this PR does

The shipped `ascend-device-plugin.yaml` mounts a per-node config file (from configmap `hami-device-node-config`) at `/node-config.yaml`, but the container `args` only pass `--config_file`. The `--node_config_file` flag is never set.

Since `cmd/main.go` guards node-config loading with:

```go
nodeConfigFile = flag.String("node_config_file", "", "node specific config file path")
...
if *nodeConfigFile != "" {
    err = mgr.LoadNodeConfig(*nodeConfigFile, *nodeName)
}
```

and the flag defaults to empty, `LoadNodeConfig` is **never called**. As a result any per-node setting (e.g. `hami-vnpu-core: true`, `vDeviceCount`) placed in the mounted node-config is silently ignored — the file is mounted but unused.

This PR simply passes the flag (the file is already mounted):

```yaml
args:
  - --config_file
  - /device-config.yaml
  - --node_config_file
  - /node-config.yaml
```

## Evidence

On a real 8×910B4 node:

- Without the flag: the `hami-vnpu-core` node annotation stays `false`; the mounted node-config has no effect.
- After adding `--node_config_file /node-config.yaml` to the DaemonSet args, the log immediately shows:

  ```
  manager.go:72 Successfully matched node config for node-001: {Name:node-001 HamiVnpuCore:true VDeviceCount:8}
  ```

  and the node annotation flips to `hami-vnpu-core=true`. The feature works — the manifest just didn't wire the flag.

## Scope

Manifest-only change (one flag). No code change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for an additional node-specific configuration file alongside the existing device configuration, enabling more flexible deployment setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
---

*AI assistance disclosure (per the project's AI Assistance Notice): the missing flag was found while testing per-node config on a real Ascend 910B4 node, where the node config never loaded until `--node_config_file` was added and the log then showed `Successfully matched node config`. This manifest one-liner was prepared with AI assistance (Claude Code) and verified by me on that node. I understand the change and stand behind it.*
