### PR TITLE
fix(ascend): honor nodeConfig.VDeviceCount in VDeviceCount()

### DIFF
--- a/internal/manager/manager.go
+++ b/internal/manager/manager.go
@@ -132,6 +132,12 @@ func (am *AscendManager) ResourceName() string {
 }
 
 func (am *AscendManager) VDeviceCount() int {
+	// Prefer the per-node override when present, mirroring IsHamiVnpuCore().
+	// The node config is loaded into am.nodeConfig from --node_config_file;
+	// a positive VDeviceCount there takes precedence over the global default.
+	if am.nodeConfig != nil && am.nodeConfig.VDeviceCount > 0 {
+		return am.nodeConfig.VDeviceCount
+	}
 	if len(am.config.Templates) == 0 {
 		return 1
 	}

--- a/internal/manager/manager.go
+++ b/internal/manager/manager.go
@@ -133,8 +133,6 @@ func (am *AscendManager) ResourceName() string {
 
 func (am *AscendManager) VDeviceCount() int {
 	// Prefer the per-node override when present, mirroring IsHamiVnpuCore().
-	// The node config is loaded into am.nodeConfig from --node_config_file;
-	// a positive VDeviceCount there takes precedence over the global default.
 	if am.nodeConfig != nil && am.nodeConfig.VDeviceCount > 0 {
 		return am.nodeConfig.VDeviceCount
 	}

--- a/internal/manager/manager_test.go
+++ b/internal/manager/manager_test.go
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2026 The HAMi Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package manager
+
+import (
+	"testing"
+
+	"github.com/Project-HAMi/ascend-device-plugin/internal"
+)
+
+// TestVDeviceCount verifies that VDeviceCount honors a per-node override
+// (nodeConfig.VDeviceCount) when present, and otherwise falls back to the
+// global default derived from MemoryAllocatable / smallest template.
+//
+// This guards the fix for the bug where VDeviceCount ignored the loaded
+// nodeConfig.VDeviceCount and always used the global default, even though the
+// sibling IsHamiVnpuCore() already preferred nodeConfig.
+func TestVDeviceCount(t *testing.T) {
+	// A representative Ascend910B4 config: 32768 MiB allocatable, smallest
+	// template 8192 MiB -> global default = 32768/8192 = 4 vDevices/card.
+	cfg910B4 := internal.VNPUConfig{
+		CommonWord:        "Ascend910B4",
+		MemoryAllocatable: 32768,
+		Templates: []internal.Template{
+			{Name: "vir03_1c_8g", Memory: 8192, AICore: 5},
+			{Name: "vir06_1c_16g", Memory: 16384, AICore: 10},
+			{Name: "vir12_3c_32g", Memory: 32768, AICore: 20},
+		},
+	}
+
+	tests := []struct {
+		name       string
+		config     internal.VNPUConfig
+		nodeConfig *internal.NodeConfig
+		want       int
+	}{
+		{
+			name:       "no node config -> global default (32768/8192=4)",
+			config:     cfg910B4,
+			nodeConfig: nil,
+			want:       4,
+		},
+		{
+			name:       "node config VDeviceCount=0 -> falls back to global default",
+			config:     cfg910B4,
+			nodeConfig: &internal.NodeConfig{Name: "node-001", VDeviceCount: 0},
+			want:       4,
+		},
+		{
+			name:       "node config VDeviceCount=8 -> honored (the fix)",
+			config:     cfg910B4,
+			nodeConfig: &internal.NodeConfig{Name: "node-001", VDeviceCount: 8},
+			want:       8,
+		},
+		{
+			name:       "node config VDeviceCount=2 -> honored, tracks the value",
+			config:     cfg910B4,
+			nodeConfig: &internal.NodeConfig{Name: "node-001", VDeviceCount: 2},
+			want:       2,
+		},
+		{
+			name:       "no templates, no node config -> 1",
+			config:     internal.VNPUConfig{CommonWord: "AscendX", MemoryAllocatable: 32768},
+			nodeConfig: nil,
+			want:       1,
+		},
+		{
+			name:       "no templates but node override present -> node override wins",
+			config:     internal.VNPUConfig{CommonWord: "AscendX", MemoryAllocatable: 32768},
+			nodeConfig: &internal.NodeConfig{Name: "node-001", VDeviceCount: 5},
+			want:       5,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			am := &AscendManager{
+				config:     tt.config,
+				nodeConfig: tt.nodeConfig,
+			}
+			if got := am.VDeviceCount(); got != tt.want {
+				t.Fatalf("VDeviceCount() = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/manager/manager_test.go
+++ b/internal/manager/manager_test.go
@@ -23,12 +23,7 @@ import (
 )
 
 // TestVDeviceCount verifies that VDeviceCount honors a per-node override
-// (nodeConfig.VDeviceCount) when present, and otherwise falls back to the
-// global default derived from MemoryAllocatable / smallest template.
-//
-// This guards the fix for the bug where VDeviceCount ignored the loaded
-// nodeConfig.VDeviceCount and always used the global default, even though the
-// sibling IsHamiVnpuCore() already preferred nodeConfig.
+// (nodeConfig.VDeviceCount) and otherwise falls back to the global default.
 func TestVDeviceCount(t *testing.T) {
 	// A representative Ascend910B4 config: 32768 MiB allocatable, smallest
 	// template 8192 MiB -> global default = 32768/8192 = 4 vDevices/card.


### PR DESCRIPTION
## What this PR does

`VDeviceCount()` always derived the per-card vDevice count from the global config (`MemoryAllocatable / smallest template`), **ignoring the per-node override** loaded into `am.nodeConfig` — even though the sibling method `IsHamiVnpuCore()` already prefers `am.nodeConfig`. As a result, setting `vDeviceCount` in the node config had no effect: every card kept advertising the global default slice count.

This PR makes `VDeviceCount()` prefer `nodeConfig.VDeviceCount` when present and positive, mirroring `IsHamiVnpuCore()`, and otherwise falls back to the existing global default.

```go
func (am *AscendManager) VDeviceCount() int {
	if am.nodeConfig != nil && am.nodeConfig.VDeviceCount > 0 {
		return am.nodeConfig.VDeviceCount
	}
	if len(am.config.Templates) == 0 {
		return 1
	}
	return int(am.config.MemoryAllocatable / am.config.Templates[0].Memory)
}
```

> Note: the per-node config is only loaded when the plugin is started with `--node_config_file`. The shipped `ascend-device-plugin.yaml` mounts the node-config but does not pass that flag; that is fixed separately in #99. This PR is the code side — it makes the loaded value actually take effect.

## Unit test

Added a table-driven test `TestVDeviceCount` in `internal/manager/manager_test.go` covering: no node config (global default), `VDeviceCount=0` (fallback), `VDeviceCount>0` (honored + tracks value), and the no-template edge cases.

The test **fails on the previous code and passes with this change** — proving it pins the bug:

```
# against the OLD code (before this fix):
--- FAIL: TestVDeviceCount
    --- FAIL: TestVDeviceCount/node_config_VDeviceCount=8_->_honored_(the_fix)
        manager_test.go:96: VDeviceCount() = 4, want 8
    --- FAIL: TestVDeviceCount/node_config_VDeviceCount=2_->_honored,_tracks_the_value
        manager_test.go:96: VDeviceCount() = 4, want 2
    --- FAIL: TestVDeviceCount/no_templates_but_node_override_present_->_node_override_wins
        manager_test.go:96: VDeviceCount() = 1, want 5

# with this fix:
ok  	github.com/Project-HAMi/ascend-device-plugin/internal/manager	0.002s
--- PASS: TestVDeviceCount (0.00s)  [all 6 sub-cases PASS]
```

## Real-hardware verification (8× Ascend 910B4)

Built this branch into an arm64 image and ran it on a real node with **8× Ascend 910B4** (driver 25.5.1, k8s v1.29.15, containerd 1.7.13). To avoid disturbing the node's existing device plugin, the test plugin used a **distinct `commonWord`/`resourceName`** (`huawei.com/Ascend910B4-f2test`) — a fully isolated, additive registration.

The `910B4` config has `memoryAllocatable=32768` and smallest template `8192`, so the global default is `32768/8192 = 4` vDevices/card. Evidence, per tier — the per-card `count` comes from the plugin's own HAMi node-register annotation, cross-checked against the kubelet-advertised resource capacity (8 cards):

| node config | plugin log | per-card `count` (register annotation) | node capacity (8 cards) |
|---|---|---|---|
| *(vDeviceCount unset)* | `matched node config … VDeviceCount:0` | `[4,4,4,4,4,4,4,4]` | `32` |
| `vDeviceCount: 8` | `matched node config … VDeviceCount:8` | `[8,8,8,8,8,8,8,8]` | `64` |
| `vDeviceCount: 2` | `matched node config … VDeviceCount:2` | `[2,2,2,2,2,2,2,2]` | `16` |

- **Unset → global default (4)**: unchanged behavior, no regression.
- **Set → honored and tracks the value (8→8, 2→2)** on real hardware.

All test resources were removed after the run.

## Scope / safety of the test

The real-hardware test ran as a **fully isolated, additive** deployment: a separate namespace, a distinct `commonWord`/`resourceName` (`huawei.com/Ascend910B4-f2test`) so it never collided with the production `huawei.com/Ascend910B4` registration or its HAMi node annotations. All test resources were removed afterward and the node was restored to its exact prior state.

---

*AI assistance disclosure (per the project's AI Assistance Notice): the underlying issue was diagnosed from my own testing on real Ascend 910B4 hardware. The one-function change and the unit test were drafted with AI assistance (Claude Code) and then reviewed, built, and verified by me on the hardware described above. I understand the change and stand behind it.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * `VDeviceCount()` now honors a per-node vDevice override when a node configuration is present and the override is greater than zero.
  * When no valid override applies (including missing templates), it falls back to the computed default, using a safe value of `1` as needed.

* **Tests**
  * Added unit test coverage for `VDeviceCount()` across default, node-overridden, zero-value override, and missing-template scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->