### PR TITLE
fix: mount host /usr/local/sbin so device-plugin finds npu-smi

### DIFF
--- a/ascend-device-plugin.yaml
+++ b/ascend-device-plugin.yaml
@@ -82,6 +82,9 @@ spec:
             - name: hiai-driver
               mountPath: /usr/local/Ascend/driver
               readOnly: true
+            - name: host-sbin
+              mountPath: /usr/local/sbin
+              readOnly: true
             - name: log-path
               mountPath: /var/log/mindx-dl/devicePlugin
             - name: tmp
@@ -113,6 +116,10 @@ spec:
         - name: hiai-driver
           hostPath:
             path: /usr/local/Ascend/driver
+        - name: host-sbin
+          hostPath:
+            path: /usr/local/sbin
+            type: DirectoryOrCreate
         - name: log-path
           hostPath:
             path: /var/log/mindx-dl/devicePlugin

--- a/charts/ascend-device-plugin/templates/daemonset.yaml
+++ b/charts/ascend-device-plugin/templates/daemonset.yaml
@@ -46,6 +46,9 @@ spec:
             - name: hiai-driver
               mountPath: /usr/local/Ascend/driver
               readOnly: true
+            - name: host-sbin
+              mountPath: /usr/local/sbin
+              readOnly: true
             - name: log-path
               mountPath: /var/log/mindx-dl/devicePlugin
             - name: tmp
@@ -77,6 +80,10 @@ spec:
         - name: hiai-driver
           hostPath:
             path: /usr/local/Ascend/driver
+        - name: host-sbin
+          hostPath:
+            path: /usr/local/sbin
+            type: DirectoryOrCreate
         - name: log-path
           hostPath:
             path: /var/log/mindx-dl/devicePlugin


### PR DESCRIPTION
fix: #103
Standard Ascend driver installs place npu-smi in /usr/local/sbin, which neither the DaemonSet chart template nor the static manifest mounted, so the device-share flip failed with "npu-smi not found". Mount it read-only in both charts/ascend-device-plugin/templates/daemonset.yaml and ascend-device-plugin.yaml.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the device-plugin deployment to mount an additional host directory, `/usr/local/sbin`, into the container as a read-only path.
  * Added support for creating that host directory automatically if it is missing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->