### PR TITLE
fix(monitor): preserve workload namespace/pod labels in ServiceMonitor

### DIFF
--- a/ascend-vnpu-monitor-integration.yaml
+++ b/ascend-vnpu-monitor-integration.yaml
@@ -41,20 +41,17 @@ spec:
     - port: monitorport
       path: /metrics
       interval: 15s
+      # honorLabels keeps the exporter's workload namespace/pod (else the Operator overwrites them with the device-plugin pod)
+      honorLabels: true
       relabelings:
         - action: replace
           sourceLabels:
             - __meta_kubernetes_endpoint_node_name
           targetLabel: node
-      metricRelabelings:
         - action: replace
           sourceLabels:
-            - pod
-          targetLabel: exported_pod
-        - action: replace
-          sourceLabels:
-            - namespace
-          targetLabel: exported_namespace
+            - __meta_kubernetes_pod_name
+          targetLabel: plugin_pod
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule

--- a/internal/monitor/collector.go
+++ b/internal/monitor/collector.go
@@ -2,6 +2,7 @@ package monitor
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -151,7 +152,7 @@ func (c *vNPUCollector) collectPodMetrics(ch chan<- prometheus.Metric, devices [
 				e.Namespace,
 				e.PodName,
 				e.ContainerName,
-				"0",
+				strconv.Itoa(i),
 				devUUID,
 			}
 


### PR DESCRIPTION
## Problem

The **recommended** production path (`ascend-vnpu-monitor-integration.yaml`) loses the workload identity for per-container vNPU metrics.

### 1. ServiceMonitor overwrites workload namespace/pod

The Operator-default `honor_labels: false` causes the target labels (`namespace=kube-system`, `pod=hami-ascend-device-plugin-*`) to overwrite the exporter's workload labels (`namespace=vnpu-test`, `pod=vnpu-ent-1`). The `exported_*` metricRelabelings then overwrite the copies too, losing the workload identity entirely.

### 2. vdevice_index hardcoded to "0"

For multi-device containers (e.g. vLLM TP=2), `vdevice_index` is always `"0"` regardless of the actual device position in `DeviceUUIDs`.

## Fix

- Set `honorLabels: true` so the exporter's workload `namespace`/`pod` survive the collision
- Remove the two `exported_*` metricRelabelings (no longer needed)
- Add `plugin_pod` relabeling to preserve which device-plugin pod served the scrape, under a non-colliding label
- Change `vdevice_index` from hardcoded `"0"` to `fmt.Sprint(i)`

## Verification

Verified end-to-end on an Ascend 310P (aarch64) cluster with an A/B `kubernetes_sd` test, a real hami-core workload pod (`vnpu-test/vnpu-ent-1`), and a multi-card pod:

| Job | namespace | pod |
|---|---|---|
| **vnpu-fixed** (honor_labels:true) | `vnpu-test` ✅ | `vnpu-ent-1` ✅ |
| vnpu-operatorlike (old behavior) | `kube-system` ❌ | `hami-ascend-device-plugin-*` ❌ |

Multi-card `vdevice_index` confirmed: `"0"` / `"1"` for a pod with 2 devices.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated monitoring scrape configuration to preserve existing metric labels and add a pod-derived `plugin_pod` label for clearer identification of scraped workloads.
  * Corrected per-device metric reporting so `vdevice_index` now reflects the actual virtual GPU index rather than a constant value across all per-device metrics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->