### PR TITLE
feat: add 910c template

### DIFF
--- a/ascend-device-configmap.yaml
+++ b/ascend-device-configmap.yaml
@@ -135,3 +135,12 @@ data:
         memoryCapacity: 65536
         aiCore: 20
         aiCPU: 7
+        templates:
+          - name: vir05_1c_16g
+            memory: 16384
+            aiCore: 5
+            aiCPU: 1
+          - name: vir10_3c_32g
+            memory: 32768
+            aiCore: 10
+            aiCPU: 3


### PR DESCRIPTION
https://github.com/Project-HAMi/HAMi/pull/2005 has already added the template of 910c to HAMi. we should also add template to `ascend-device-configmap.yaml`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added device template configurations for Ascend910 devices, including memory, AI Core, and AI CPU specifications.
  * Added support for the `vir05_1c_16g` and `vir10_3c_32g` device templates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->