### PR TITLE
fix: fix docker image tag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,7 +138,7 @@ jobs:
       run: |
         if [[ "${{ github.ref }}" == refs/tags/* ]]; then
           TAG_NAME="${GITHUB_REF#refs/tags/}"
-          echo "VERSION=${TAG_NAME#v}" >> $GITHUB_OUTPUT
+          echo "VERSION=${TAG_NAME}" >> $GITHUB_OUTPUT
           echo "Extracted version: ${VERSION}"
         else
           echo "VERSION=latest" >> $GITHUB_OUTPUT


### PR DESCRIPTION
#78 removed the `v` prefix from the tag

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Docker images built from tagged releases now retain the complete tag name, including any leading “v,” in the image version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->