### PR TITLE
feat: add concurrency and permissions cfg to ci workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,14 @@ on:
   pull_request:
     branches: [ "main" ]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  packages: write
+
 env:
   GO_VERSION: "1.26.2"
 


### PR DESCRIPTION
Currently, the CI workflow lacks the concurrency control and permission restrictions required by basic GitHub workflow best practices.