### PR TITLE
fix: pass --node_config_file so hami-device-node-config takes effect

### DIFF
--- a/ascend-device-plugin.yaml
+++ b/ascend-device-plugin.yaml
@@ -66,6 +66,8 @@ spec:
           args:
             - --config_file
             - /device-config.yaml
+            - --node_config_file
+            - /node-config.yaml
             - --v=4
           ports:
             # Embedded vNPU Prometheus metrics endpoint (/metrics).

--- a/charts/ascend-device-plugin/values.yaml
+++ b/charts/ascend-device-plugin/values.yaml
@@ -11,6 +11,8 @@ daemonSet:
   args:
     - --config_file
     - /device-config.yaml
+    - --node_config_file
+    - /node-config.yaml
     - --v=4
 
 rbac:


### PR DESCRIPTION
The ConfigMap is mounted at /node-config.yaml but the DaemonSet args never passed --node_config_file, so main.go never loaded the per-node config. Add the flag to the standalone manifest and Helm chart args. #115 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for loading node-specific configuration through the device plugin deployment.
  * Updated default deployment settings to include the node configuration file alongside the existing device configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->