### PR TITLE
docs: fix `npu-smi` location description

### DIFF
--- a/docs/hami.md
+++ b/docs/hami.md
@@ -11,10 +11,10 @@ This guide covers deploying `ascend-device-plugin` for use with the [HAMi](https
 - **Ascend Driver Version**: ≥ 25.5
 - **`npu-smi` must be reachable on the host**, at one of the following paths (checked in order):
   1. `/usr/local/Ascend/driver/tools/npu-smi` (from the existing driver hostPath mount)
-  2. `/usr/local/sbin/npu-smi`
+  2. `/usr/local/sbin/npu-smi` (mounted by default)
   3. `/usr/local/bin/npu-smi`
 
-  If your host ships `npu-smi` elsewhere, add a hostPath mount for it in `ascend-device-plugin.yaml`.
+  If `npu-smi` is located at `/usr/local/bin/npu-smi`, please add the path mount in `ascend-device-plugin.yaml`.
 
 - **HAMi Version**:
   - ≥ 2.7.0 for template-based hard slicing (vNPU)

--- a/docs/hami_cn.md
+++ b/docs/hami_cn.md
@@ -11,10 +11,10 @@
 - Ascend 驱动版本：≥ 25.5
 - **`npu-smi` 必须在宿主机上可访问**，按以下顺序查找：
   1. `/usr/local/Ascend/driver/tools/npu-smi`（由已有的 driver hostPath 挂载提供）
-  2. `/usr/local/sbin/npu-smi`
+  2. `/usr/local/sbin/npu-smi` (默认挂载路径)
   3. `/usr/local/bin/npu-smi`
 
-  若宿主机的 `npu-smi` 在其他位置，可在 `ascend-device-plugin.yaml` 中为其增加 hostPath 挂载。
+  若宿主机的 `npu-smi` 在 `/usr/local/bin/npu-smi`，需要在 `ascend-device-plugin.yaml` 中为其增加 hostPath 挂载。
 
 - **HAMi 版本**：
   - 基于模板的硬切分 (vNPU) 最低版本：≥ 2.7.0

--- a/docs/volcano.md
+++ b/docs/volcano.md
@@ -12,10 +12,10 @@ This guide covers deploying `ascend-device-plugin` for use with the [Volcano](ht
 - **Ascend Driver Version**: ≥ 25.5
 - **`npu-smi` must be reachable on the host** (only needed for `hami-core` soft slicing), at one of the following paths (checked in order):
   1. `/usr/local/Ascend/driver/tools/npu-smi` (from the existing driver hostPath mount)
-  2. `/usr/local/sbin/npu-smi`
+  2. `/usr/local/sbin/npu-smi` (mounted by default)
   3. `/usr/local/bin/npu-smi`
 
-  If your host ships `npu-smi` elsewhere, add a hostPath mount for it in `ascend-device-plugin.yaml`.
+  If `npu-smi` is located at `/usr/local/bin/npu-smi`, please add the path mount in `ascend-device-plugin.yaml`.
 
 **Note:** `hami-core` soft slicing currently only supports ARM platforms; template-based hard slicing has no such restriction.
 

--- a/docs/volcano_cn.md
+++ b/docs/volcano_cn.md
@@ -12,10 +12,10 @@
 - Ascend 驱动版本：≥ 25.5
 - **`npu-smi` 必须在宿主机上可访问**（仅 `hami-core` 软切分需要），按以下顺序查找：
   1. `/usr/local/Ascend/driver/tools/npu-smi`（由已有的 driver hostPath 挂载提供）
-  2. `/usr/local/sbin/npu-smi`
+  2. `/usr/local/sbin/npu-smi` (默认挂载路径)
   3. `/usr/local/bin/npu-smi`
 
-  若宿主机的 `npu-smi` 在其他位置，可在 `ascend-device-plugin.yaml` 中为其增加 hostPath 挂载。
+  若宿主机的 `npu-smi` 在 `/usr/local/bin/npu-smi`，需要在 `ascend-device-plugin.yaml` 中为其增加 hostPath 挂载。
 
 **注意：** `hami-core` 软切分目前仅支持 ARM 平台；基于模板的硬切分没有此限制。
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified the expected locations and fallback order for the `npu-smi` binary in HAMi deployment prerequisites.
  * Added specific guidance for configuring the required host path when `npu-smi` is located at `/usr/local/bin/npu-smi`.
  * Updated both English and Chinese documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->