### PR TITLE
fix(server): allow disabling periodic idle vNPU cleanup to avoid premature reclamation

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -35,11 +35,12 @@ import (
 )
 
 var (
-	hwLoglevel            = flag.Int("hw_loglevel", 0, "huawei log level, -1-debug, 0-info, 1-warning, 2-error 3-critical default value: 0")
-	configFile            = flag.String("config_file", "", "config file path")
-	nodeConfigFile        = flag.String("node_config_file", "", "node specific config file path")
-	nodeName              = flag.String("node_name", os.Getenv("NODE_NAME"), "node name")
-	checkIdleVNPUInterval = flag.Int("check_idle_vnpu_interval", 60, "the interval (in seconds) to check idle vNPU and release them")
+	hwLoglevel                    = flag.Int("hw_loglevel", 0, "huawei log level, -1-debug, 0-info, 1-warning, 2-error 3-critical default value: 0")
+	configFile                    = flag.String("config_file", "", "config file path")
+	nodeConfigFile                = flag.String("node_config_file", "", "node specific config file path")
+	nodeName                      = flag.String("node_name", os.Getenv("NODE_NAME"), "node name")
+	checkIdleVNPUInterval         = flag.Int("check_idle_vnpu_interval", 60, "the interval (in seconds) to check idle vNPU and release them")
+	enablePeriodicIdleVNPUCleanup = flag.Bool("enable_periodic_idle_vnpu_cleanup", false, "whether to enable the periodic idle vNPU cleanup goroutine; when disabled, the one-shot cleanup on restart still runs (default false: periodic cleanup disabled)")
 )
 
 func checkFlags() {
@@ -144,7 +145,7 @@ func main() {
 			klog.Errorf("load node config failed: %v", err)
 		}
 	}
-	server, err := server.NewPluginServer(mgr, *nodeName, *checkIdleVNPUInterval)
+	server, err := server.NewPluginServer(mgr, *nodeName, *checkIdleVNPUInterval, *enablePeriodicIdleVNPUCleanup)
 	if err != nil {
 		klog.Fatalf("init PluginServer failed, error is %v", err)
 	}

--- a/internal/server/register.go
+++ b/internal/server/register.go
@@ -35,10 +35,9 @@ import (
 	"github.com/Project-HAMi/HAMi/pkg/util"
 )
 
-// watchAndRegister must be launched with ps.wg.Add(1) already called by the
-// caller (see Start()); doing the Add here would race with Stop()'s wg.Wait().
+// watchAndRegister is launched via ps.wg.Go in Start(), which owns the
+// WaitGroup Add(1)/Done() pairing; this function must not call wg.Done itself.
 func (ps *PluginServer) watchAndRegister() {
-	defer ps.wg.Done()
 	timer := time.After(1 * time.Second)
 	for {
 		select {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -58,19 +58,20 @@ var (
 type PluginServer struct {
 	v1beta1.UnimplementedDevicePluginServer
 
-	commonWord            string
-	nodeName              string
-	registerAnno          string
-	handshakeAnno         string
-	allocAnno             string
-	toAllocDeviceAnno     string
-	grpcServer            *grpc.Server
-	mgr                   manager.Manager
-	socket                string
-	stopCh                chan interface{}
-	healthCh              chan int32
-	checkIdleVNPUInterval int
-	wg                    sync.WaitGroup
+	commonWord                    string
+	nodeName                      string
+	registerAnno                  string
+	handshakeAnno                 string
+	allocAnno                     string
+	toAllocDeviceAnno             string
+	grpcServer                    *grpc.Server
+	mgr                           manager.Manager
+	socket                        string
+	stopCh                        chan any
+	healthCh                      chan int32
+	checkIdleVNPUInterval         int
+	enablePeriodicIdleVNPUCleanup bool
+	wg                            sync.WaitGroup
 
 	// test hooks — injected by tests to avoid real socket/kubelet dependencies
 	dialFunc                 func(unixSocketPath string, timeout time.Duration) (*grpc.ClientConn, error)
@@ -85,20 +86,21 @@ type RuntimeInfo struct {
 	Core   *int32 `json:"core,omitempty"`
 }
 
-func NewPluginServer(mgr manager.Manager, nodeName string, checkIdleVNPUInterval int) (*PluginServer, error) {
+func NewPluginServer(mgr manager.Manager, nodeName string, checkIdleVNPUInterval int, enablePeriodicIdleVNPUCleanup bool) (*PluginServer, error) {
 	commonWord := mgr.CommonWord()
 	server := &PluginServer{
-		commonWord:            commonWord,
-		nodeName:              nodeName,
-		registerAnno:          fmt.Sprintf("hami.io/node-register-%s", commonWord),
-		handshakeAnno:         fmt.Sprintf("hami.io/node-handshake-%s", commonWord),
-		allocAnno:             fmt.Sprintf("huawei.com/%s", commonWord),
-		toAllocDeviceAnno:     fmt.Sprintf("hami.io/%s-devices-to-allocate", commonWord),
-		mgr:                   mgr,
-		socket:                path.Join(v1beta1.DevicePluginPath, fmt.Sprintf("%s.sock", commonWord)),
-		stopCh:                make(chan interface{}),
-		healthCh:              make(chan int32),
-		checkIdleVNPUInterval: checkIdleVNPUInterval,
+		commonWord:                    commonWord,
+		nodeName:                      nodeName,
+		registerAnno:                  fmt.Sprintf("hami.io/node-register-%s", commonWord),
+		handshakeAnno:                 fmt.Sprintf("hami.io/node-handshake-%s", commonWord),
+		allocAnno:                     fmt.Sprintf("huawei.com/%s", commonWord),
+		toAllocDeviceAnno:             fmt.Sprintf("hami.io/%s-devices-to-allocate", commonWord),
+		mgr:                           mgr,
+		socket:                        path.Join(v1beta1.DevicePluginPath, fmt.Sprintf("%s.sock", commonWord)),
+		stopCh:                        make(chan any),
+		healthCh:                      make(chan int32),
+		checkIdleVNPUInterval:         checkIdleVNPUInterval,
+		enablePeriodicIdleVNPUCleanup: enablePeriodicIdleVNPUCleanup,
 	}
 	// enable calling hami methods
 	device.InRequestDevices[commonWord] = server.toAllocDeviceAnno
@@ -121,7 +123,7 @@ func (ps *PluginServer) Start() error {
 		return err
 	}
 
-	ps.stopCh = make(chan interface{})
+	ps.stopCh = make(chan any)
 	ps.grpcServer = grpc.NewServer()
 
 	err := ps.mgr.UpdateDevice()
@@ -139,19 +141,16 @@ func (ps *PluginServer) Start() error {
 	if err != nil {
 		return err
 	}
-	// Add to the WaitGroup synchronously before launching the goroutines.
-	// sync.WaitGroup requires a positive Add (from a zero counter) to
-	// happen-before Wait; doing Add inside the goroutine races with Stop()'s
-	// Wait and panics with "WaitGroup is reused before previous Wait has returned".
-	ps.wg.Add(1)
-	go ps.startPeriodicCheckIdleVNPUs()
-	ps.wg.Add(1)
-	go ps.watchAndRegister()
+	// sync.WaitGroup.Go handles the Add(1)/Done() pairing internally, so the
+	// goroutine bodies no longer need their own defer ps.wg.Done().
+	if ps.enablePeriodicIdleVNPUCleanup {
+		ps.wg.Go(ps.startPeriodicCheckIdleVNPUs)
+	}
+	ps.wg.Go(ps.watchAndRegister)
 	return nil
 }
 
 func (ps *PluginServer) startPeriodicCheckIdleVNPUs() {
-	defer ps.wg.Done()
 	ticker := time.NewTicker(time.Duration(ps.checkIdleVNPUInterval) * time.Second)
 	defer ticker.Stop()
 	for {
@@ -185,7 +184,7 @@ func (ps *PluginServer) Stop() error {
 	return nil
 }
 
-func (ps *PluginServer) StopCh() <-chan interface{} {
+func (ps *PluginServer) StopCh() <-chan any {
 	return ps.stopCh
 }
 
@@ -201,9 +200,7 @@ func (ps *PluginServer) serve() error {
 	}
 	v1beta1.RegisterDevicePluginServer(ps.grpcServer, ps)
 	resourceName := ps.mgr.ResourceName()
-	ps.wg.Add(1)
-	go func() {
-		defer ps.wg.Done()
+	ps.wg.Go(func() {
 		lastCrashTime := time.Now()
 		restartCount := 0
 		for {
@@ -236,7 +233,7 @@ func (ps *PluginServer) serve() error {
 				restartCount++
 			}
 		}
-	}()
+	})
 
 	// Wait for server to start by launching a blocking connexion
 	conn, err := ps.dial(ps.socket, 5*time.Second)
@@ -257,7 +254,7 @@ func (ps *PluginServer) apiDevices() []*v1beta1.Device {
 		if dev.Health {
 			health = v1beta1.Healthy
 		}
-		for i := 0; i < vCount; i++ {
+		for i := range vCount {
 			device := v1beta1.Device{
 				ID:     fmt.Sprintf("%s-%d", dev.UUID, i),
 				Health: health,

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"os"
 	"path"
+	"slices"
 	"strings"
 	"testing"
 
@@ -128,8 +129,8 @@ func setupAllocateEnv(nodeName, podName, podNamespace string, numContainers int,
 // composeCleanup combines multiple CleanupFuncs into one that runs in reverse order.
 func composeCleanup(fns ...CleanupFunc) CleanupFunc {
 	return func() {
-		for i := len(fns) - 1; i >= 0; i-- {
-			fns[i]()
+		for _, fn := range slices.Backward(fns) {
+			fn()
 		}
 	}
 }
@@ -534,7 +535,7 @@ func TestNewPluginServer(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			mgr := &FakeManager{CommonWordFunc: func() string { return tc.args.commonWord }}
-			ps, err := NewPluginServer(mgr, tc.args.nodeName, 60)
+			ps, err := NewPluginServer(mgr, tc.args.nodeName, 60, false)
 			if (err != nil) != tc.wantErr {
 				t.Fatalf("NewPluginServer() error = %v, wantErr %v", err, tc.wantErr)
 			}
@@ -569,7 +570,7 @@ func TestNewPluginServer_RegistersInRequestDevices(t *testing.T) {
 	mgr := &FakeManager{
 		CommonWordFunc: func() string { return commonWord },
 	}
-	ps, err := NewPluginServer(mgr, "test-node", 60)
+	ps, err := NewPluginServer(mgr, "test-node", 60, false)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -790,32 +791,32 @@ func newPanicOnFatalLogger() *panicOnFatalLogger {
 
 var _ grpclog.LoggerV2 = (*panicOnFatalLogger)(nil)
 
-func (l *panicOnFatalLogger) Info(args ...interface{})   { l.inner.Info(args...) }
-func (l *panicOnFatalLogger) Infoln(args ...interface{}) { l.inner.Infoln(args...) }
-func (l *panicOnFatalLogger) Infof(format string, args ...interface{}) {
+func (l *panicOnFatalLogger) Info(args ...any)   { l.inner.Info(args...) }
+func (l *panicOnFatalLogger) Infoln(args ...any) { l.inner.Infoln(args...) }
+func (l *panicOnFatalLogger) Infof(format string, args ...any) {
 	l.inner.Infof(format, args...)
 }
-func (l *panicOnFatalLogger) Warning(args ...interface{})   { l.inner.Warning(args...) }
-func (l *panicOnFatalLogger) Warningln(args ...interface{}) { l.inner.Warningln(args...) }
-func (l *panicOnFatalLogger) Warningf(format string, args ...interface{}) {
+func (l *panicOnFatalLogger) Warning(args ...any)   { l.inner.Warning(args...) }
+func (l *panicOnFatalLogger) Warningln(args ...any) { l.inner.Warningln(args...) }
+func (l *panicOnFatalLogger) Warningf(format string, args ...any) {
 	l.inner.Warningf(format, args...)
 }
-func (l *panicOnFatalLogger) Error(args ...interface{})   { l.inner.Error(args...) }
-func (l *panicOnFatalLogger) Errorln(args ...interface{}) { l.inner.Errorln(args...) }
-func (l *panicOnFatalLogger) Errorf(format string, args ...interface{}) {
+func (l *panicOnFatalLogger) Error(args ...any)   { l.inner.Error(args...) }
+func (l *panicOnFatalLogger) Errorln(args ...any) { l.inner.Errorln(args...) }
+func (l *panicOnFatalLogger) Errorf(format string, args ...any) {
 	l.inner.Errorf(format, args...)
 }
 func (l *panicOnFatalLogger) V(level int) bool { return l.inner.V(level) }
 
-func (l *panicOnFatalLogger) Fatalf(format string, args ...interface{}) {
+func (l *panicOnFatalLogger) Fatalf(format string, args ...any) {
 	panic(fmt.Sprintf("grpc FATAL: "+format, args...))
 }
 
-func (l *panicOnFatalLogger) Fatalln(args ...interface{}) {
+func (l *panicOnFatalLogger) Fatalln(args ...any) {
 	panic(fmt.Sprintf("grpc FATAL: %v", fmt.Sprintln(args...)))
 }
 
-func (l *panicOnFatalLogger) Fatal(args ...interface{}) {
+func (l *panicOnFatalLogger) Fatal(args ...any) {
 	panic(fmt.Sprintf("grpc FATAL: %v", fmt.Sprint(args...)))
 }
 
@@ -825,17 +826,18 @@ func setupRestartablePluginServer(t *testing.T) *PluginServer {
 	t.Helper()
 
 	ps := &PluginServer{
-		commonWord:            "test-ascend",
-		registerAnno:          "hami.io/node-register-test-ascend",
-		handshakeAnno:         "hami.io/node-handshake-test-ascend",
-		allocAnno:             "huawei.com/test-ascend",
-		toAllocDeviceAnno:     "hami.io/test-ascend-devices-to-allocate",
-		mgr:                   &FakeManager{ResourceNameFunc: func() string { return "test-ascend" }},
-		socket:                path.Join(t.TempDir(), "test-ascend.sock"),
-		stopCh:                make(chan interface{}),
-		healthCh:              make(chan int32),
-		checkIdleVNPUInterval: 3600,
-		dialFunc:              nil,
+		commonWord:                    "test-ascend",
+		registerAnno:                  "hami.io/node-register-test-ascend",
+		handshakeAnno:                 "hami.io/node-handshake-test-ascend",
+		allocAnno:                     "huawei.com/test-ascend",
+		toAllocDeviceAnno:             "hami.io/test-ascend-devices-to-allocate",
+		mgr:                           &FakeManager{ResourceNameFunc: func() string { return "test-ascend" }},
+		socket:                        path.Join(t.TempDir(), "test-ascend.sock"),
+		stopCh:                        make(chan any),
+		healthCh:                      make(chan int32),
+		checkIdleVNPUInterval:         3600,
+		enablePeriodicIdleVNPUCleanup: true,
+		dialFunc:                      nil,
 		registerKubeletFunc: func() error {
 			return nil
 		},
@@ -883,7 +885,7 @@ func TestGrpcServer_MultipleRestarts(t *testing.T) {
 
 	ps := setupRestartablePluginServer(t)
 
-	for i := 0; i < 5; i++ {
+	for i := range 5 {
 		if err := ps.Start(); err != nil {
 			t.Fatalf("Start() iteration %d failed: %v", i, err)
 		}


### PR DESCRIPTION
## What & Why

Issue #86 reports that the periodic idle vNPU cleanup goroutine (`startPeriodicCheckIdleVNPUs`) destroys vNPUs based solely on `IsContainerUsed == 0`. Because a vNPU allocated to a Pod that is already `Running` but whose container has not yet started using the NPU **also** reports `IsContainerUsed == 0`, the cleanup can reclaim the vNPU too early — breaking workloads (e.g. `npu-smi info` fails inside the container shortly after the Pod starts).

#86 is framed as a discussion and lists several more thorough directions (combining `IsContainerUsed` with Pod allocation state, adding a protection window, or a Pod-referenced rule like `mind-cluster`'s `DestroyNotUsedVNPU`). Those require deeper changes to the cleanup policy.

This PR takes a smaller, complementary step: give operators a switch to **disable the periodic cleanup goroutine** so the premature-reclamation symptom stops on affected nodes without waiting for the larger redesign.

## Changes

- New bool flag `--enable_periodic_idle_vnpu_cleanup` (default `false`). When `false`, `Start()` does not launch the periodic `startPeriodicCheckIdleVNPUs` goroutine.
- The one-shot `CleanupIdleVNPUs()` on plugin restart (`cmd/main.go`) is intentionally left unconditional and unchanged — it is a separate entry point. The flag name (`enable_periodic_...`) and its help text make this boundary explicit to avoid the "total cleanup switch" ambiguity.
- Wiring threaded through `NewPluginServer`.

## Scope note

This is a **mitigation**, not a full resolution of #86's cleanup-policy discussion. The flag defaults to `false` (periodic cleanup disabled) to stop the premature-reclamation symptom by default; setting it to `true` restores the previous behavior. Reviewers may prefer a different default — easy to adjust.

## Testing

- `go build ./internal/server/... ./cmd/...` ✅
- `go vet ./internal/server/... ./cmd/...` ✅
- `go test ./internal/server/` — 109 passed, consistent with baseline (ran 3×)

## Modernizations (in the touched files)

While editing these files I also applied the Go modernization lints the editor flagged. All behavior-preserving; happy to split into a separate PR if preferred:

- `interface{}` → `any`
- `wg.Add(1)` + `go func(){ defer Done() }` → `wg.Go(...)`
- `for i := 0; i < n; i++` → `for i := range n`
- reverse index loop → `slices.Backward`

Refs #86


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a CLI option `--enable_periodic_idle_vnpu_cleanup` to enable periodic cleanup of idle vNPU resources.
  * Cleanup remains disabled by default.
* **Bug Fixes**
  * Improved server goroutine lifecycle and shutdown coordination for more reliable startup and termination.
* **Tests**
  * Updated server tests to match the new cleanup configuration and constructor signature, including restart-related scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
