### PR TITLE
docs: add Ascend contribution templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,0 +1,38 @@
+---
+name: Bug Report
+about: Report a problem encountered while using ascend-device-plugin
+labels: bug
+---
+
+<!-- Please use this template while reporting a bug and provide as much info as possible. Not doing so may result in your bug not being addressed in a timely manner. Thanks!
+-->
+
+**What happened**:
+
+**What you expected to happen**:
+
+**How to reproduce it (as minimally and precisely as possible)**:
+
+**Anything else we need to know?**:
+
+- Relevant excerpts from `npu-smi info`; mask NPU serial numbers, device identifiers, and host or node identifiers
+- Relevant Docker or containerd configuration sections. Omit credentials, tokens, passwords, private keys, certificates, and unrelated host data.
+- Relevant, time-bounded excerpts from the ascend-device-plugin container logs
+- Relevant, time-bounded excerpts from the HAMi scheduler or Volcano scheduler container logs
+- Relevant, time-bounded excerpts from the kubelet logs on the node (e.g: `sudo journalctl -r -u kubelet`)
+- The relevant Helm values, ConfigMaps, or deployment manifests
+- Relevant, time-bounded kernel output lines from `dmesg`
+
+Before posting, remove or mask credentials, tokens, NPU identifiers, node or host identifiers, and other sensitive data from configuration and logs.
+
+**Environment**:
+- ascend-device-plugin version:
+- Ascend NPU model:
+- Ascend driver and CANN version:
+- Kubernetes version:
+- HAMi or Volcano version:
+- Docker or containerd version:
+- Installation method, image, and tag used:
+- Slicing mode (`vNPU` or `hami-vnpu-core`):
+- Kernel version from `uname -a`:
+- Others:

--- a/.github/ISSUE_TEMPLATE/enhancement.md
+++ b/.github/ISSUE_TEMPLATE/enhancement.md
@@ -1,0 +1,13 @@
+---
+name: Enhancement Request
+about: Suggest an improvement to ascend-device-plugin
+labels: enhancement
+---
+
+<!-- Please use this template for enhancement and feature requests. -->
+
+**What would you like to be added**:
+
+**Why is this needed**:
+
+**Anything else we need to know?**:

--- a/.github/ISSUE_TEMPLATE/good-first.md
+++ b/.github/ISSUE_TEMPLATE/good-first.md
@@ -1,0 +1,23 @@
+---
+name: Good First Issue
+about: Publish a task suitable for a first-time contributor
+labels: "good first issue"
+---
+
+<!-- Please use this template when publishing a good first issue. -->
+
+**Task description**:
+
+**Suggested solution**:
+
+**Who can take this task**:
+
+This issue is intended for a first-time contributor beginning their contribution journey.
+
+**How to take the task**:
+
+Reply to the issue and state that you would like to work on it. A maintainer can assign it to you.
+
+**How to ask for help**:
+
+If you need assistance or have questions, ask in the issue. The issue author or another community member can provide guidance.

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,0 +1,21 @@
+---
+name: Question
+about: Ask a question about ascend-device-plugin
+labels: question
+---
+
+**Please provide a detailed description of your question**:
+
+**What have you already tried or investigated?**:
+
+Before posting, include only relevant, time-bounded excerpts and remove or mask credentials, tokens, NPU identifiers, and node or host identifiers.
+
+**Environment**:
+
+- ascend-device-plugin version:
+- Ascend NPU model:
+- Ascend driver and CANN version:
+- Kubernetes version:
+- HAMi or Volcano version:
+- Installation method and slicing mode:
+- Others:

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,26 @@
+**What type of PR is this?**
+
+<!--
+Add one of the following kinds:
+/kind bug
+/kind cleanup
+/kind deprecation
+/kind design
+/kind documentation
+/kind failing-test
+/kind feature
+/kind flake
+-->
+
+**What this PR does / why we need it**:
+
+**Which issue(s) this PR fixes**:
+Fixes #
+
+**Special notes for your reviewer**:
+
+**Does this PR introduce a user-facing change?**:
+
+**AI Disclosure**:
+
+<!-- Briefly disclose any AI assistance used. Do not add AI co-author or assistance trailers to commits. -->


### PR DESCRIPTION
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
-->

/kind documentation

**What this PR does / why we need it**:

Adds concise, repository-specific templates for bug reports, enhancements, good first issues, questions, and pull requests. This helps reports collect consistent Ascend NPU, CANN, scheduler, runtime, and reproduction details while keeping project behavior unchanged.

**Which issue(s) this PR fixes**:
Fixes #123

**Special notes for your reviewer**:

This is a documentation-only change. The issue-template front matter was parsed locally, uses existing repository labels, and all five Markdown files were checked for whitespace errors. Diagnostic prompts request only relevant, time-bounded excerpts and require sensitive identifiers to be masked.

**Does this PR introduce a user-facing change?**:

Yes. Contributors will see repository-specific prompts when opening issues and pull requests.

**AI Disclosure**:

AI was used only for formatting purposes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added templates for bug reports, enhancement requests, questions, and good-first issues.
  * Added prompts for reproduction steps, environment details, diagnostics, task planning, and sanitized information.
  * Added a pull request template covering change type, linked issues, reviewer notes, user-facing impact, and AI assistance disclosure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->