### PR TITLE
fix(server): stop ListAndWatch on stream closure

### DIFF
--- a/internal/server/list_and_watch_test.go
+++ b/internal/server/list_and_watch_test.go
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2026 The HAMi Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package server
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"google.golang.org/grpc"
+	"k8s.io/kubelet/pkg/apis/deviceplugin/v1beta1"
+)
+
+type fakeListAndWatchServer struct {
+	grpc.ServerStream
+	ctx      context.Context
+	sendFunc func(*v1beta1.ListAndWatchResponse) error
+}
+
+func (s *fakeListAndWatchServer) Context() context.Context {
+	return s.ctx
+}
+
+func (s *fakeListAndWatchServer) Send(resp *v1beta1.ListAndWatchResponse) error {
+	return s.sendFunc(resp)
+}
+
+func TestListAndWatchReturnsInitialSendError(t *testing.T) {
+	wantErr := errors.New("stream closed")
+	stopCh := make(chan any)
+	close(stopCh)
+	ps := &PluginServer{
+		mgr:    &FakeManager{},
+		stopCh: stopCh,
+	}
+	stream := &fakeListAndWatchServer{
+		ctx: context.Background(),
+		sendFunc: func(*v1beta1.ListAndWatchResponse) error {
+			return wantErr
+		},
+	}
+
+	err := ps.ListAndWatch(&v1beta1.Empty{}, stream)
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("ListAndWatch() error = %v, want %v", err, wantErr)
+	}
+}
+
+func TestListAndWatchReturnsHealthUpdateSendError(t *testing.T) {
+	wantErr := errors.New("stream closed")
+	stopCh := make(chan any)
+	healthCh := make(chan int32, 1)
+	healthCh <- 0
+	ps := &PluginServer{
+		mgr:      &FakeManager{},
+		stopCh:   stopCh,
+		healthCh: healthCh,
+	}
+	sendCount := 0
+	stream := &fakeListAndWatchServer{
+		ctx: context.Background(),
+		sendFunc: func(*v1beta1.ListAndWatchResponse) error {
+			sendCount++
+			if sendCount == 2 {
+				close(stopCh)
+				return wantErr
+			}
+			return nil
+		},
+	}
+
+	err := ps.ListAndWatch(&v1beta1.Empty{}, stream)
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("ListAndWatch() error = %v, want %v", err, wantErr)
+	}
+}
+
+func TestListAndWatchReturnsWhenStreamIsCanceled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	ps := &PluginServer{
+		mgr:      &FakeManager{},
+		stopCh:   make(chan any),
+		healthCh: make(chan int32),
+	}
+	stream := &fakeListAndWatchServer{
+		ctx: ctx,
+		sendFunc: func(*v1beta1.ListAndWatchResponse) error {
+			return nil
+		},
+	}
+
+	err := ps.ListAndWatch(&v1beta1.Empty{}, stream)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("ListAndWatch() error = %v, want %v", err, context.Canceled)
+	}
+}

--- a/internal/server/list_and_watch_test.go
+++ b/internal/server/list_and_watch_test.go
@@ -92,6 +92,7 @@ func TestListAndWatchReturnsHealthUpdateSendError(t *testing.T) {
 func TestListAndWatchReturnsWhenStreamIsCanceled(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
+	sendCount := 0
 	ps := &PluginServer{
 		mgr:      &FakeManager{},
 		stopCh:   make(chan any),
@@ -100,6 +101,7 @@ func TestListAndWatchReturnsWhenStreamIsCanceled(t *testing.T) {
 	stream := &fakeListAndWatchServer{
 		ctx: ctx,
 		sendFunc: func(*v1beta1.ListAndWatchResponse) error {
+			sendCount++
 			return nil
 		},
 	}
@@ -107,5 +109,8 @@ func TestListAndWatchReturnsWhenStreamIsCanceled(t *testing.T) {
 	err := ps.ListAndWatch(&v1beta1.Empty{}, stream)
 	if !errors.Is(err, context.Canceled) {
 		t.Fatalf("ListAndWatch() error = %v, want %v", err, context.Canceled)
+	}
+	if sendCount != 0 {
+		t.Fatalf("Send() calls = %d, want 0", sendCount)
 	}
 }

--- a/internal/server/list_and_watch_test.go
+++ b/internal/server/list_and_watch_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	"google.golang.org/grpc"
 	"k8s.io/kubelet/pkg/apis/deviceplugin/v1beta1"
@@ -112,5 +113,50 @@ func TestListAndWatchReturnsWhenStreamIsCanceled(t *testing.T) {
 	}
 	if sendCount != 0 {
 		t.Fatalf("Send() calls = %d, want 0", sendCount)
+	}
+}
+
+func TestListAndWatchReturnsWhenStreamIsCanceledWhileWaiting(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	ps := &PluginServer{
+		mgr:      &FakeManager{},
+		stopCh:   make(chan any),
+		healthCh: make(chan int32),
+	}
+	initialSent := make(chan struct{}, 1)
+	sendCount := 0
+	stream := &fakeListAndWatchServer{
+		ctx: ctx,
+		sendFunc: func(*v1beta1.ListAndWatchResponse) error {
+			sendCount++
+			initialSent <- struct{}{}
+			return nil
+		},
+	}
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- ps.ListAndWatch(&v1beta1.Empty{}, stream)
+	}()
+
+	select {
+	case <-initialSent:
+	case <-time.After(time.Second):
+		t.Fatal("initial Send() was not called")
+	}
+	cancel()
+
+	select {
+	case err := <-errCh:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("ListAndWatch() error = %v, want %v", err, context.Canceled)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("ListAndWatch() did not return after stream cancellation")
+	}
+	if sendCount != 1 {
+		t.Fatalf("Send() calls = %d, want 1", sendCount)
 	}
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -271,6 +271,9 @@ func (ps *PluginServer) GetDevicePluginOptions(context.Context, *v1beta1.Empty) 
 }
 
 func (ps *PluginServer) ListAndWatch(e *v1beta1.Empty, s v1beta1.DevicePlugin_ListAndWatchServer) error {
+	if err := s.Context().Err(); err != nil {
+		return err
+	}
 	if err := s.Send(&v1beta1.ListAndWatchResponse{Devices: ps.apiDevices()}); err != nil {
 		return fmt.Errorf("send initial device list: %w", err)
 	}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -271,13 +271,19 @@ func (ps *PluginServer) GetDevicePluginOptions(context.Context, *v1beta1.Empty) 
 }
 
 func (ps *PluginServer) ListAndWatch(e *v1beta1.Empty, s v1beta1.DevicePlugin_ListAndWatchServer) error {
-	_ = s.Send(&v1beta1.ListAndWatchResponse{Devices: ps.apiDevices()})
+	if err := s.Send(&v1beta1.ListAndWatchResponse{Devices: ps.apiDevices()}); err != nil {
+		return fmt.Errorf("send initial device list: %w", err)
+	}
 	for {
 		select {
 		case <-ps.stopCh:
 			return nil
+		case <-s.Context().Done():
+			return s.Context().Err()
 		case <-ps.healthCh:
-			_ = s.Send(&v1beta1.ListAndWatchResponse{Devices: ps.apiDevices()})
+			if err := s.Send(&v1beta1.ListAndWatchResponse{Devices: ps.apiDevices()}); err != nil {
+				return fmt.Errorf("send device health update: %w", err)
+			}
 		}
 	}
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

The device plugin’s `ListAndWatch` implementation previously ignored errors returned by the gRPC stream’s `Send` method and did not observe stream-context cancellation.

After kubelet disconnected or closed the stream, the handler could remain blocked on the health or server-stop channels, leaving a stale goroutine alive until the plugin stopped.

This PR:

- Returns errors from initial and health-update `Send` calls.
- Stops `ListAndWatch` when the stream context is cancelled.
- Adds regression tests for initial-send failure, health-update failure, and context cancellation.

**Which issue(s) this PR fixes**:

Fixes #125 

**Special notes for your reviewer**:

The change is limited to the `ListAndWatch` stream lifecycle. It does not modify device discovery, allocation, scheduling, resource accounting, or either slicing mode.

Verification performed on macOS/arm64:

- `make test`
- `go vet ./internal/...`
- Targeted regression tests repeated 100 times
- Targeted race-detector tests repeated 100 times
- Device-plugin binary build
- CI-equivalent golangci-lint: `0 issues`
- `git diff --check`

The repository does not currently define a generic `make verify` target. Its available verification targets are Helm-specific and unrelated to this server change.

**Does this PR introduce a user-facing change?**:

NONE

**AI Disclosure**:

AI assistance was used to inspect the stream lifecycle, draft the focused implementation, and prepare regression tests. The resulting diff was reviewed locally and verified using the test, race, vet, lint, and build checks listed above.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes

* Improved device-list streaming reliability by reporting errors when initial or health updates cannot be sent.
* Properly handles canceled streaming connections, including cancellations before the initial response and while waiting for updates.

## Tests

* Added coverage for initial response failures, health-update failures, and stream cancellation scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->