### PR TITLE
fix: accept the pre-v2.9.0 HAMi device config layout

### DIFF
--- a/docs/hami.md
+++ b/docs/hami.md
@@ -22,6 +22,8 @@ This guide covers deploying `ascend-device-plugin` for use with the [HAMi](https
 
   Both require `devices.ascend.enabled: true` to be set when deploying HAMi.
 
+  HAMi v2.9.0 moved the Ascend chip list from `vnpus` to `vnpus.configs` in the `hami-scheduler-device` ConfigMap. The plugin reads both layouts, and logs a warning when it falls back to the older one, so it can be upgraded ahead of HAMi.
+
 **Note:** `hami-vnpu-core` soft slicing currently only supports ARM platforms; template-based hard slicing has no such restriction.
 
 ## Deployment
@@ -41,7 +43,7 @@ kubectl apply -f https://raw.githubusercontent.com/Project-HAMi/ascend-device-pl
 ### Deploy ConfigMap
 
 * **HAMi and `ascend-device-plugin` in the same namespace (recommended)**: skip this step — HAMi's existing `hami-scheduler-device` ConfigMap already covers Ascend.
-* **Different namespaces**: deploy the Ascend ConfigMap into `ascend-device-plugin`'s own namespace, then manually merge its `vnpus:` section into HAMi's existing `hami-scheduler-device` ConfigMap without touching HAMi's other device entries. Keep both copies in sync whenever you change templates, resourceNames, or `hamiVnpuCore`.
+* **Different namespaces**: deploy the Ascend ConfigMap into `ascend-device-plugin`'s own namespace, then manually merge its `vnpus:` section into HAMi's existing `hami-scheduler-device` ConfigMap without touching HAMi's other device entries. On HAMi < v2.9.0, keep that ConfigMap's own `vnpus` list layout — its scheduler cannot read `vnpus.configs`. Keep both copies in sync whenever you change templates, resourceNames, or `hamiVnpuCore`.
 
   ```bash
   kubectl apply -f https://raw.githubusercontent.com/Project-HAMi/ascend-device-plugin/main/ascend-device-configmap.yaml

--- a/docs/hami_cn.md
+++ b/docs/hami_cn.md
@@ -22,6 +22,8 @@
 
   两种模式都需要在部署 HAMi 时设置 `devices.ascend.enabled: true`。
 
+  HAMi v2.9.0 把 `hami-scheduler-device` ConfigMap 中的 Ascend 芯片列表从 `vnpus` 挪到了 `vnpus.configs`。插件两种格式都能读，回退到旧格式时会打一条告警日志，因此可以先于 HAMi 升级。
+
 **注意：** `hami-vnpu-core` 软切分目前仅支持 ARM 平台；基于模板的硬切分没有此限制。
 
 ## 部署
@@ -41,7 +43,7 @@ kubectl apply -f https://raw.githubusercontent.com/Project-HAMi/ascend-device-pl
 ### 部署 ConfigMap
 
 * **HAMi 和 `ascend-device-plugin` 在同一命名空间(推荐)**：跳过这一步，HAMi 现有的 `hami-scheduler-device` 已经包含 Ascend 配置。
-* **不同命名空间**：把 Ascend 的 ConfigMap 部署到 `ascend-device-plugin` 自己的命名空间下，然后手动把其中的 `vnpus:` 部分合并进 HAMi 现有的 `hami-scheduler-device`，不要动 HAMi 其他设备的配置。以后修改模板、resourceName 或 `hamiVnpuCore` 时，两边同步更新。
+* **不同命名空间**：把 Ascend 的 ConfigMap 部署到 `ascend-device-plugin` 自己的命名空间下，然后手动把其中的 `vnpus:` 部分合并进 HAMi 现有的 `hami-scheduler-device`，不要动 HAMi 其他设备的配置。若 HAMi < v2.9.0，合并时要保留它自己的 `vnpus` 列表写法——那边的调度器读不了 `vnpus.configs`。以后修改模板、resourceName 或 `hamiVnpuCore` 时，两边同步更新。
 
   ```bash
   kubectl apply -f https://raw.githubusercontent.com/Project-HAMi/ascend-device-plugin/main/ascend-device-configmap.yaml

--- a/internal/manager/manager_test.go
+++ b/internal/manager/manager_test.go
@@ -17,7 +17,13 @@
 package manager
 
 import (
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
+
+	"ascend-common/devmanager"
+	"ascend-common/devmanager/common"
 
 	"github.com/Project-HAMi/ascend-device-plugin/internal"
 )
@@ -91,5 +97,120 @@ func TestVDeviceCount(t *testing.T) {
 				t.Fatalf("VDeviceCount() = %d, want %d", got, tt.want)
 			}
 		})
+	}
+}
+
+// chipInfoDeviceManager reports a fixed chip so LoadConfig can pick an entry
+// without a real NPU.
+type chipInfoDeviceManager struct {
+	*devmanager.DeviceManagerMock
+	chipName string
+}
+
+func (d *chipInfoDeviceManager) GetValidChipInfo() (common.ChipInfo, error) {
+	return common.ChipInfo{Type: "Ascend", Name: d.chipName}, nil
+}
+
+func writeConfig(t *testing.T, content string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "device-config.yaml")
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	return path
+}
+
+// TestLoadConfigAcrossHAMiVersions checks that the manager resolves its own
+// chip out of a multi-chip list in either layout, so that upgrading the plugin
+// ahead of HAMi does not break startup.
+func TestLoadConfigAcrossHAMiVersions(t *testing.T) {
+	// Two chips so that picking the right entry, not just the first one, is
+	// actually exercised. 910B3: 65536/16384 = 4 vDevices; 910B4: 32768/8192 = 4.
+	const chips = `
+- chipName: 910B3
+  commonWord: Ascend910B3
+  resourceName: huawei.com/Ascend910B3
+  memoryAllocatable: 65536
+  templates:
+  - {name: vir10_3c_32g, memory: 32768}
+  - {name: vir05_1c_16g, memory: 16384}
+- chipName: 910B4
+  commonWord: Ascend910B4
+  resourceName: huawei.com/Ascend910B4
+  memoryAllocatable: 32768
+  templates:
+  - {name: vir05_1c_8g, memory: 8192}
+`
+	// The same chips under `vnpus.configs:` need one more level of indentation.
+	currentLayout := "vnpus:\n  hamiVnpuCore: true\n  configs:" + strings.ReplaceAll(chips, "\n", "\n  ")
+	legacyLayout := "vnpus:" + chips
+
+	tests := []struct {
+		name             string
+		content          string
+		chipName         string
+		wantCommonWord   string
+		wantResourceName string
+		wantHamiVnpuCore bool
+	}{
+		{
+			name:             "current layout",
+			content:          currentLayout,
+			chipName:         "910B3",
+			wantCommonWord:   "Ascend910B3",
+			wantResourceName: "huawei.com/Ascend910B3",
+			wantHamiVnpuCore: true,
+		},
+		{
+			name:             "legacy layout, second entry",
+			content:          legacyLayout,
+			chipName:         "910B4",
+			wantCommonWord:   "Ascend910B4",
+			wantResourceName: "huawei.com/Ascend910B4",
+			wantHamiVnpuCore: false,
+		},
+		{
+			name:             "legacy layout with top-level hamiVnpuCore",
+			content:          "hamiVnpuCore: true\n" + legacyLayout,
+			chipName:         "910B3",
+			wantCommonWord:   "Ascend910B3",
+			wantResourceName: "huawei.com/Ascend910B3",
+			wantHamiVnpuCore: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			am := &AscendManager{mgr: &chipInfoDeviceManager{chipName: tt.chipName}}
+			if err := am.LoadConfig(writeConfig(t, tt.content)); err != nil {
+				t.Fatalf("LoadConfig() error = %v, want nil", err)
+			}
+			if got := am.CommonWord(); got != tt.wantCommonWord {
+				t.Errorf("CommonWord() = %q, want %q", got, tt.wantCommonWord)
+			}
+			if got := am.ResourceName(); got != tt.wantResourceName {
+				t.Errorf("ResourceName() = %q, want %q", got, tt.wantResourceName)
+			}
+			if got := am.VDeviceCount(); got != 4 {
+				t.Errorf("VDeviceCount() = %d, want 4", got)
+			}
+			if got := am.IsHamiVnpuCore(); got != tt.wantHamiVnpuCore {
+				t.Errorf("IsHamiVnpuCore() = %v, want %v", got, tt.wantHamiVnpuCore)
+			}
+		})
+	}
+}
+
+// TestLoadConfigChipNotFound keeps the "no entry for this chip" path distinct
+// from a parse failure in both layouts.
+func TestLoadConfigChipNotFound(t *testing.T) {
+	path := writeConfig(t, "vnpus:\n- chipName: 910B3\n  commonWord: Ascend910B3\n")
+	am := &AscendManager{mgr: &chipInfoDeviceManager{chipName: "310P3"}}
+	err := am.LoadConfig(path)
+	if err == nil {
+		t.Fatal("LoadConfig() error = nil, want an error")
+	}
+	if !strings.Contains(err.Error(), "310P3") {
+		t.Errorf("LoadConfig() error = %v, want it to name the missing chip", err)
 	}
 }

--- a/internal/vnpu.go
+++ b/internal/vnpu.go
@@ -17,9 +17,12 @@ limitations under the License.
 package internal
 
 import (
+	"encoding/json"
+	"errors"
 	"os"
 
 	"k8s.io/apimachinery/pkg/util/yaml"
+	"k8s.io/klog/v2"
 )
 
 type Template struct {
@@ -50,6 +53,13 @@ type Config struct {
 	VNPUs VNPUsConfig `json:"vnpus"`
 }
 
+// legacyConfig is the device-config.yaml layout of HAMi <= v2.8.x, where vnpus
+// is a plain list; v2.9.0 moved that list under vnpus.configs.
+type legacyConfig struct {
+	HamiVnpuCore bool         `json:"hamiVnpuCore,omitempty"`
+	VNPUs        []VNPUConfig `json:"vnpus"`
+}
+
 // FilterDevices defines devices that should be ignored by HAMi.
 // A device is ignored when its UUID is listed in UUID or its index is listed in Index.
 type FilterDevices struct {
@@ -65,6 +75,17 @@ func (fd FilterDevices) HasUUID() bool {
 	return len(fd.UUID) > 0
 }
 
+// isLegacyVNPUsLayout reports whether err is the "vnpus holds a list" mismatch
+// a HAMi <= v2.8.x device config produces. Any other decoding failure, deeper
+// errors inside vnpus included, is a genuine one and keeps its own message.
+func isLegacyVNPUsLayout(err error) bool {
+	var typeErr *json.UnmarshalTypeError
+	return errors.As(err, &typeErr) && typeErr.Field == "vnpus" && typeErr.Value == "array"
+}
+
+// LoadConfig reads the hami-scheduler-device config, accepting both the
+// HAMi >= v2.9.0 layout and the older one so that upgrading this plugin does
+// not require upgrading HAMi at the same time.
 func LoadConfig(path string) (*Config, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
@@ -72,10 +93,20 @@ func LoadConfig(path string) (*Config, error) {
 	}
 	var yamlData Config
 	err = yaml.Unmarshal(data, &yamlData)
-	if err != nil {
+	if err == nil {
+		return &yamlData, nil
+	}
+	if !isLegacyVNPUsLayout(err) {
 		return nil, err
 	}
-	return &yamlData, nil
+
+	var legacy legacyConfig
+	if err := yaml.Unmarshal(data, &legacy); err != nil {
+		return nil, err
+	}
+	klog.Warningf("%s uses the device config layout of HAMi <= v2.8.x (vnpus holds a list); upgrade HAMi "+
+		"to v2.9.0+ to get vnpus.hamiVnpuCore and hami-core soft slicing", path)
+	return &Config{VNPUs: VNPUsConfig{HamiVnpuCore: legacy.HamiVnpuCore, Configs: legacy.VNPUs}}, nil
 }
 
 type NodeConfig struct {

--- a/internal/vnpu_test.go
+++ b/internal/vnpu_test.go
@@ -1,0 +1,279 @@
+/*
+ * Copyright 2026 The HAMi Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package internal
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/util/yaml"
+)
+
+// currentFormat is what HAMi >= v2.9.0 writes into the hami-scheduler-device
+// ConfigMap: `vnpus` is a mapping holding hamiVnpuCore plus a configs list.
+const currentFormat = `
+vnpus:
+  hamiVnpuCore: true
+  configs:
+  - chipName: 910B4
+    commonWord: Ascend910B4
+    resourceName: huawei.com/Ascend910B4
+    resourceMemoryName: huawei.com/Ascend910B4-memory
+    memoryAllocatable: 32768
+    memoryCapacity: 32768
+    aiCore: 20
+    aiCPU: 7
+    templates:
+      - name: vir05_1c_8g
+        memory: 8192
+        aiCore: 5
+        aiCPU: 1
+      - name: vir10_3c_16g
+        memory: 16384
+        aiCore: 10
+        aiCPU: 3
+`
+
+// legacyFormat carries the very same chip as currentFormat, in the layout HAMi
+// v2.7.0 - v2.8.x writes: `vnpus` is a plain list and there is no hamiVnpuCore.
+const legacyFormat = `
+vnpus:
+- chipName: 910B4
+  commonWord: Ascend910B4
+  resourceName: huawei.com/Ascend910B4
+  resourceMemoryName: huawei.com/Ascend910B4-memory
+  memoryAllocatable: 32768
+  memoryCapacity: 32768
+  aiCore: 20
+  aiCPU: 7
+  templates:
+    - name: vir05_1c_8g
+      memory: 8192
+      aiCore: 5
+      aiCPU: 1
+    - name: vir10_3c_16g
+      memory: 16384
+      aiCore: 10
+      aiCPU: 3
+`
+
+// legacyFormatWithHamiVnpuCore is the pre-v2.9.0 layout this plugin used to
+// ship in ascend-device-configmap.yaml: the switch sat next to the list.
+const legacyFormatWithHamiVnpuCore = "hamiVnpuCore: true\n" + legacyFormat
+
+// otherVendorSections mirrors a real hami-scheduler-device ConfigMap, which
+// carries every vendor's config in the same document.
+const otherVendorSections = `
+nvidia:
+  resourceCountName: nvidia.com/gpu
+  resourceMemoryName: nvidia.com/gpumem
+cambricon:
+  resourceCountName: cambricon.com/vmlu
+`
+
+// wantVNPUs is what every fixture above must decode to. Comparing whole values
+// against it is what keeps the two layouts honest: a field the fallback forgets
+// to carry over, or a fixture that drifts, fails the test.
+func wantVNPUs(hamiVnpuCore bool) VNPUsConfig {
+	return VNPUsConfig{
+		HamiVnpuCore: hamiVnpuCore,
+		Configs: []VNPUConfig{{
+			ChipName:           "910B4",
+			CommonWord:         "Ascend910B4",
+			ResourceName:       "huawei.com/Ascend910B4",
+			ResourceMemoryName: "huawei.com/Ascend910B4-memory",
+			MemoryAllocatable:  32768,
+			MemoryCapacity:     32768,
+			AICore:             20,
+			AICPU:              7,
+			Templates: []Template{
+				{Name: "vir05_1c_8g", Memory: 8192, AICore: 5, AICPU: 1},
+				{Name: "vir10_3c_16g", Memory: 16384, AICore: 10, AICPU: 3},
+			},
+		}},
+	}
+}
+
+func writeConfig(t *testing.T, content string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "device-config.yaml")
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	return path
+}
+
+// TestLoadConfigAcceptsBothLayouts is the compatibility contract: the plugin
+// must read the HAMi >= v2.9.0 device-config.yaml and the older one alike, and
+// expose both through the same Config.
+func TestLoadConfigAcceptsBothLayouts(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+		want    VNPUsConfig
+	}{
+		{
+			name:    "current layout",
+			content: currentFormat,
+			want:    wantVNPUs(true),
+		},
+		{
+			name:    "current layout alongside other vendors",
+			content: otherVendorSections + currentFormat,
+			want:    wantVNPUs(true),
+		},
+		{
+			name:    "current layout wins over a leftover top-level hamiVnpuCore",
+			content: "hamiVnpuCore: false\n" + currentFormat,
+			want:    wantVNPUs(true),
+		},
+		{
+			name:    "legacy layout",
+			content: legacyFormat,
+			want:    wantVNPUs(false),
+		},
+		{
+			name:    "legacy layout alongside other vendors",
+			content: otherVendorSections + legacyFormat,
+			want:    wantVNPUs(false),
+		},
+		{
+			name:    "legacy layout with top-level hamiVnpuCore",
+			content: legacyFormatWithHamiVnpuCore,
+			want:    wantVNPUs(true),
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			config, err := LoadConfig(writeConfig(t, tc.content))
+			if err != nil {
+				t.Fatalf("LoadConfig() error = %v, want nil", err)
+			}
+			if !reflect.DeepEqual(config.VNPUs, tc.want) {
+				t.Errorf("VNPUs = %+v, want %+v", config.VNPUs, tc.want)
+			}
+		})
+	}
+}
+
+// TestLoadConfigWithoutChips covers the configs that declare no Ascend chip:
+// they must stay a successful parse, so the caller reports "no vnpu config for
+// chip X" rather than a parse error.
+func TestLoadConfigWithoutChips(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+	}{
+		{name: "no vnpus section at all", content: otherVendorSections},
+		{name: "current layout, empty configs", content: "vnpus:\n  configs: []\n"},
+		{name: "legacy layout, empty list", content: "vnpus: []\n"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			config, err := LoadConfig(writeConfig(t, tc.content))
+			if err != nil {
+				t.Fatalf("LoadConfig() error = %v, want nil", err)
+			}
+			if len(config.VNPUs.Configs) != 0 {
+				t.Errorf("len(VNPUs.Configs) = %d, want 0", len(config.VNPUs.Configs))
+			}
+		})
+	}
+}
+
+// TestLoadConfigErrors keeps the original behaviour for input that matches
+// neither layout, and checks the error still points at what is actually wrong:
+// falling back must not turn a plain typo into "neither layout matched".
+func TestLoadConfigErrors(t *testing.T) {
+	tests := []struct {
+		name     string
+		path     string
+		contains string
+	}{
+		{
+			name: "file does not exist",
+			path: filepath.Join(t.TempDir(), "missing.yaml"),
+		},
+		{
+			name: "not valid yaml",
+			path: writeConfig(t, "vnpus:\n\t- chipName: 910B4\n  bad indent\n"),
+		},
+		{
+			name:     "vnpus is neither a list nor a mapping",
+			path:     writeConfig(t, "vnpus: 910B4\n"),
+			contains: "Config.vnpus",
+		},
+		{
+			name:     "wrong type inside the current layout",
+			path:     writeConfig(t, "vnpus:\n  configs:\n  - memoryAllocatable: not-a-number\n"),
+			contains: "vnpus.configs.memoryAllocatable",
+		},
+		{
+			name:     "wrong type inside the legacy layout",
+			path:     writeConfig(t, "vnpus:\n- chipName: [910B4]\n"),
+			contains: "vnpus.chipName",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := LoadConfig(tc.path)
+			if err == nil {
+				t.Fatal("LoadConfig() error = nil, want an error")
+			}
+			if tc.contains != "" && !strings.Contains(err.Error(), tc.contains) {
+				t.Errorf("LoadConfig() error = %v, want it to mention %q", err, tc.contains)
+			}
+		})
+	}
+}
+
+// TestIsLegacyVNPUsLayout pins down the discriminator that decides whether to
+// retry with the older layout. It is deliberately fed real YAML rather than
+// hand-built errors: if a future yaml library stops wrapping
+// *json.UnmarshalTypeError, or encoding/json stops reporting nested fields with
+// a dotted path, this fails instead of the fallback silently going dead.
+func TestIsLegacyVNPUsLayout(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+		want    bool
+	}{
+		{name: "legacy layout", content: legacyFormat, want: true},
+		{name: "legacy layout, empty list", content: "vnpus: []\n", want: true},
+		{name: "current layout, nothing to classify", content: currentFormat, want: false},
+		{name: "vnpus is a scalar", content: "vnpus: 910B4\n", want: false},
+		{name: "wrong type under vnpus.configs", content: "vnpus:\n  configs:\n  - memoryAllocatable: x\n", want: false},
+		{name: "wrong type under vnpus.configs.templates", content: "vnpus:\n  configs:\n  - templates:\n    - memory: x\n", want: false},
+		{name: "yaml syntax error", content: "vnpus:\n\t- chipName: 910B4\n", want: false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var config Config
+			err := yaml.Unmarshal([]byte(tc.content), &config)
+			if got := isLegacyVNPUsLayout(err); got != tc.want {
+				t.Errorf("isLegacyVNPUsLayout(%v) = %v, want %v", err, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
-->

**What this PR does / why we need it**:
HAMi v2.9.0 moved the Ascend chip list in the `hami-scheduler-device` ConfigMap from `vnpus` to `vnpus.configs`, and this plugin followed in `cc588e4`. It now only parses the new layout, so against HAMi v2.7.0 - v2.8.3, which all write `vnpus` as a list, it dies at startup:

```
load config failed, error is failed to load config from /device-config.yaml:
error unmarshaling JSON: while decoding JSON: json: cannot unmarshal array
into Go struct field Config.vnpus of type internal.VNPUsConfig
```

`docs/hami.md` still lists HAMi >= 2.7.0 as enough for template-based hard slicing.

`LoadConfig` now retries with the old layout and warns, but only on the `UnmarshalTypeError` that layout produces (an array fed to `vnpus`). Every other failure keeps its own error.

`docs/hami.md` also gains a note that merging this repo's `vnpus:` block into a pre-v2.9.0 HAMi ConfigMap must keep that ConfigMap's own list layout, since its scheduler cannot read `vnpus.configs`.

**Which issue(s) this PR fixes**:
NONE

**Special notes for your reviewer**:
Nothing else needs changing for an older HAMi: the register annotation, the devices-to-allocate encoding, the `huawei.com/<commonWord>` runtime info and the bind-phase handling are identical between v2.8.x and master.

Checked on an Ascend 910B4 node (8 cards, driver 25.5.1): fed the old layout, config loading fails before the patch and works after, resolving the same chip config and the same 8 devices as the new layout.

AI assistance disclosure: this PR was written primarily by Claude Code. I reviewed the change, the tests and the hardware run myself.

**Does this PR introduce a user-facing change?**:
ascend-device-plugin again accepts the device-config.yaml layout of HAMi v2.7.0 - v2.8.x instead of failing to start against it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for HAMi v2.9.0’s nested `vnpus.configs` configuration format.
  * Maintained compatibility with legacy `vnpus` configurations, with a warning when the older format is detected.
  * Improved chip matching, virtual device count calculation, and `hamiVnpuCore` handling.

* **Documentation**
  * Updated English and Chinese deployment guidance, including version-specific configuration requirements.

* **Bug Fixes**
  * Added clearer handling for missing chips, empty configurations, malformed input, and invalid configuration types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->