### PR TITLE
fix(server): refresh the device cache on every watch tick

### DIFF
--- a/internal/server/register.go
+++ b/internal/server/register.go
@@ -35,6 +35,11 @@ import (
 	"github.com/Project-HAMi/HAMi/pkg/util"
 )
 
+// healthUpdateSendTimeout bounds how long watchAndRegister waits for a
+// ListAndWatch consumer to accept a device update before moving on. It is a
+// variable so tests can shorten it.
+var healthUpdateSendTimeout = 5 * time.Second
+
 // watchAndRegister is launched via ps.wg.Go in Start(), which owns the
 // WaitGroup Add(1)/Done() pairing; this function must not call wg.Done itself.
 func (ps *PluginServer) watchAndRegister() {
@@ -46,14 +51,31 @@ func (ps *PluginServer) watchAndRegister() {
 			return
 		case <-timer:
 		}
-		unhealthy := ps.mgr.GetUnHealthIDs()
-		if len(unhealthy) > 0 {
-			if err := ps.mgr.UpdateDevice(); err != nil {
-				klog.Errorf("update device error: %v", err)
-				timer = time.After(5 * time.Second)
-				continue
+		// Refresh the cached device view on every tick. Refreshing only while
+		// GetUnHealthIDs() is non-empty leaves the cache stale forever once a
+		// device recovers between two ticks: kubelet keeps the device list it
+		// was told about at startup — typically all Unhealthy when the plugin
+		// starts before the driver finished initialising — and only a plugin
+		// restart gets the node out of it.
+		if err := ps.mgr.UpdateDevice(); err != nil {
+			klog.Errorf("update device error: %v", err)
+			timer = time.After(5 * time.Second)
+			continue
+		}
+		// Publish to kubelet whenever the device set changed, in either
+		// direction. The send is bounded so that a missing ListAndWatch
+		// consumer cannot stall this loop, which would also stop the HAMi node
+		// registration below.
+		if fp := ps.deviceFingerprint(); fp != ps.lastPublishedDevices {
+			select {
+			case ps.healthCh <- 0:
+				ps.lastPublishedDevices = fp
+			case <-ps.stopCh:
+				klog.Infof("stop watch and register")
+				return
+			case <-time.After(healthUpdateSendTimeout):
+				klog.Warningf("no ListAndWatch consumer accepted the device update, retrying later")
 			}
-			ps.healthCh <- unhealthy[0]
 		}
 		err := ps.registerHAMi()
 		if err != nil {
@@ -64,6 +86,21 @@ func (ps *PluginServer) watchAndRegister() {
 			timer = time.After(30 * time.Second)
 		}
 	}
+}
+
+// deviceFingerprint summarises the device set that apiDevices() would publish,
+// so that a change in device count or in per-device health can be detected.
+func (ps *PluginServer) deviceFingerprint() string {
+	var sb strings.Builder
+	for _, dev := range ps.mgr.GetDevices() {
+		sb.WriteString(dev.UUID)
+		if dev.Health {
+			sb.WriteString("=1;")
+		} else {
+			sb.WriteString("=0;")
+		}
+	}
+	return sb.String()
 }
 
 func (ps *PluginServer) registerHAMi() error {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -73,6 +73,11 @@ type PluginServer struct {
 	enablePeriodicIdleVNPUCleanup bool
 	wg                            sync.WaitGroup
 
+	// lastPublishedDevices fingerprints the device set most recently handed to
+	// kubelet through ListAndWatch, so watchAndRegister only pushes an update
+	// when the set actually changed.
+	lastPublishedDevices string
+
 	// test hooks — injected by tests to avoid real socket/kubelet dependencies
 	dialFunc                 func(unixSocketPath string, timeout time.Duration) (*grpc.ClientConn, error)
 	registerKubeletFunc      func() error
@@ -130,6 +135,8 @@ func (ps *PluginServer) Start() error {
 	if err != nil {
 		return err
 	}
+	// The device set below is what the first ListAndWatch response publishes.
+	ps.lastPublishedDevices = ps.deviceFingerprint()
 	if err := ps.enableNodeDeviceShare(); err != nil {
 		return err
 	}

--- a/internal/server/watch_and_register_test.go
+++ b/internal/server/watch_and_register_test.go
@@ -1,0 +1,325 @@
+/*
+ * Copyright 2024 The HAMi Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"google.golang.org/grpc"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/kubelet/pkg/apis/deviceplugin/v1beta1"
+
+	"github.com/Project-HAMi/HAMi/pkg/device"
+	"github.com/Project-HAMi/HAMi/pkg/util/client"
+	"github.com/Project-HAMi/ascend-device-plugin/internal/manager"
+)
+
+const (
+	watchRegisterNode       = "test-node"
+	watchRegisterCommonWord = "Ascend910B4-1"
+	// watchAndRegister runs its first iteration one second after it starts.
+	watchRegisterRunFor = 2 * time.Second
+)
+
+// cachingFakeManager reproduces AscendManager's caching semantics on top of a
+// mutable hardware view: UpdateDevice() copies the hardware view into the
+// cache, GetDevices() returns the cache, and GetUnHealthIDs() reads the
+// hardware live. That distinction is what the tests below exercise.
+type cachingFakeManager struct {
+	*FakeManager
+
+	mu       sync.Mutex
+	hardware []*manager.Device
+	cache    []*manager.Device
+	updates  atomic.Int32
+}
+
+func newCachingFakeManager(hardware ...*manager.Device) *cachingFakeManager {
+	m := &cachingFakeManager{hardware: hardware}
+	m.FakeManager = &FakeManager{
+		CommonWordFunc:     func() string { return watchRegisterCommonWord },
+		ResourceNameFunc:   func() string { return "huawei.com/" + watchRegisterCommonWord },
+		VDeviceCountFunc:   func() int { return 4 },
+		IsHamiVnpuCoreFunc: func() bool { return false },
+		UpdateDeviceFunc: func() error {
+			m.mu.Lock()
+			defer m.mu.Unlock()
+			m.updates.Add(1)
+			m.cache = make([]*manager.Device, 0, len(m.hardware))
+			for _, dev := range m.hardware {
+				copied := *dev
+				m.cache = append(m.cache, &copied)
+			}
+			return nil
+		},
+		GetDevicesFunc: func() []*manager.Device {
+			m.mu.Lock()
+			defer m.mu.Unlock()
+			return m.cache
+		},
+		GetUnHealthIDsFunc: func() []int32 {
+			m.mu.Lock()
+			defer m.mu.Unlock()
+			var unhealthy []int32
+			for _, dev := range m.hardware {
+				if !dev.Health {
+					unhealthy = append(unhealthy, dev.LogicID)
+				}
+			}
+			return unhealthy
+		},
+	}
+	return m
+}
+
+func (m *cachingFakeManager) setHardware(hardware ...*manager.Device) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.hardware = hardware
+}
+
+func fakeDevices(count int, healthy bool) []*manager.Device {
+	devs := make([]*manager.Device, 0, count)
+	for i := range count {
+		devs = append(devs, &manager.Device{
+			UUID:    fmt.Sprintf("uuid%d", i),
+			LogicID: int32(i),
+			PhyID:   int32(i),
+			CardID:  int32(i),
+			Memory:  65536,
+			AICore:  20,
+			Health:  healthy,
+		})
+	}
+	return devs
+}
+
+// recordingLWStream captures every device list handed to kubelet.
+type recordingLWStream struct {
+	grpc.ServerStream
+
+	mu        sync.Mutex
+	responses [][]*v1beta1.Device
+}
+
+func (s *recordingLWStream) Send(resp *v1beta1.ListAndWatchResponse) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	devices := make([]*v1beta1.Device, len(resp.Devices))
+	copy(devices, resp.Devices)
+	s.responses = append(s.responses, devices)
+	return nil
+}
+
+func (s *recordingLWStream) Context() context.Context { return context.Background() }
+
+func (s *recordingLWStream) sent() [][]*v1beta1.Device {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([][]*v1beta1.Device(nil), s.responses...)
+}
+
+func countHealthy(devices []*v1beta1.Device) int {
+	healthy := 0
+	for _, dev := range devices {
+		if dev.Health == v1beta1.Healthy {
+			healthy++
+		}
+	}
+	return healthy
+}
+
+// newWatchRegisterServer builds a PluginServer wired to mgr and to a fake
+// clientset holding the node that registerHAMi annotates. It also performs the
+// initial UpdateDevice()/fingerprint that Start() performs.
+func newWatchRegisterServer(t *testing.T, mgr *cachingFakeManager) *PluginServer {
+	t.Helper()
+
+	node := &v1.Node{ObjectMeta: metav1.ObjectMeta{
+		Name:        watchRegisterNode,
+		Annotations: map[string]string{},
+	}}
+	t.Cleanup(setupFakeClient(nil, []*v1.Node{node}))
+
+	ps := &PluginServer{
+		commonWord:        watchRegisterCommonWord,
+		nodeName:          watchRegisterNode,
+		registerAnno:      "hami.io/node-register-" + watchRegisterCommonWord,
+		handshakeAnno:     "hami.io/node-handshake-" + watchRegisterCommonWord,
+		allocAnno:         "huawei.com/" + watchRegisterCommonWord,
+		toAllocDeviceAnno: "hami.io/" + watchRegisterCommonWord + "-devices-to-allocate",
+		mgr:               mgr,
+		stopCh:            make(chan any),
+		healthCh:          make(chan int32),
+	}
+	if err := ps.mgr.UpdateDevice(); err != nil {
+		t.Fatalf("initial UpdateDevice() failed: %v", err)
+	}
+	ps.lastPublishedDevices = ps.deviceFingerprint()
+	mgr.updates.Store(0)
+	return ps
+}
+
+// runWatchAndRegister runs watchAndRegister, and optionally a ListAndWatch
+// consumer, for the given duration and then stops both.
+func runWatchAndRegister(t *testing.T, ps *PluginServer, stream *recordingLWStream, d time.Duration) {
+	t.Helper()
+
+	var wg sync.WaitGroup
+	if stream != nil {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if err := ps.ListAndWatch(&v1beta1.Empty{}, stream); err != nil {
+				t.Errorf("ListAndWatch returned an error: %v", err)
+			}
+		}()
+	}
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		ps.watchAndRegister()
+	}()
+
+	time.Sleep(d)
+	close(ps.stopCh)
+
+	done := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("watchAndRegister did not return after stopCh was closed")
+	}
+}
+
+func registeredDevices(t *testing.T, ps *PluginServer) []*device.DeviceInfo {
+	t.Helper()
+
+	node, err := client.KubeClient.CoreV1().Nodes().Get(context.Background(), ps.nodeName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get node: %v", err)
+	}
+	raw, ok := node.Annotations[ps.registerAnno]
+	if !ok {
+		t.Fatalf("annotation %s is missing", ps.registerAnno)
+	}
+	var devs []*device.DeviceInfo
+	if err := json.Unmarshal([]byte(raw), &devs); err != nil {
+		t.Fatalf("decode %s=%q: %v", ps.registerAnno, raw, err)
+	}
+	return devs
+}
+
+// TestWatchAndRegister_RepublishesRecoveredDevices covers the boot race: the
+// plugin starts while the driver still reports the devices as unhealthy, and
+// the hardware recovers right afterwards. Before the fix the cache was only
+// refreshed while GetUnHealthIDs() was non-empty, so kubelet stayed on the
+// startup device list and the node advertised no allocatable devices until the
+// Pod was restarted.
+func TestWatchAndRegister_RepublishesRecoveredDevices(t *testing.T) {
+	mgr := newCachingFakeManager(fakeDevices(4, false)...)
+	ps := newWatchRegisterServer(t, mgr)
+	stream := &recordingLWStream{}
+
+	mgr.setHardware(fakeDevices(4, true)...)
+	runWatchAndRegister(t, ps, stream, watchRegisterRunFor)
+
+	sent := stream.sent()
+	if len(sent) < 2 {
+		t.Fatalf("expected kubelet to receive an updated device list, got %d response(s)", len(sent))
+	}
+	last := sent[len(sent)-1]
+	if got, want := countHealthy(last), 4*mgr.VDeviceCount(); got != want {
+		t.Fatalf("expected %d healthy devices in the last response, got %d of %d", want, got, len(last))
+	}
+	for _, dev := range registeredDevices(t, ps) {
+		if !dev.Health {
+			t.Fatalf("expected the node register annotation to report healthy devices, got %+v", dev)
+		}
+	}
+}
+
+// TestWatchAndRegister_PublishesLateDiscoveredDevices covers the second shape
+// of the same problem: only part of the devices are enumerated when the plugin
+// starts, and the remaining ones appear a moment later.
+func TestWatchAndRegister_PublishesLateDiscoveredDevices(t *testing.T) {
+	mgr := newCachingFakeManager(fakeDevices(2, true)...)
+	ps := newWatchRegisterServer(t, mgr)
+	stream := &recordingLWStream{}
+
+	mgr.setHardware(fakeDevices(4, true)...)
+	runWatchAndRegister(t, ps, stream, watchRegisterRunFor)
+
+	sent := stream.sent()
+	last := sent[len(sent)-1]
+	if got, want := len(last), 4*mgr.VDeviceCount(); got != want {
+		t.Fatalf("expected %d devices in the last response, got %d", want, got)
+	}
+	if got := len(registeredDevices(t, ps)); got != 4 {
+		t.Fatalf("expected 4 devices in the node register annotation, got %d", got)
+	}
+}
+
+// TestWatchAndRegister_SteadyStateDoesNotResend makes sure the unconditional
+// refresh does not turn into a ListAndWatch update on every iteration.
+func TestWatchAndRegister_SteadyStateDoesNotResend(t *testing.T) {
+	mgr := newCachingFakeManager(fakeDevices(4, true)...)
+	ps := newWatchRegisterServer(t, mgr)
+	stream := &recordingLWStream{}
+
+	runWatchAndRegister(t, ps, stream, watchRegisterRunFor)
+
+	if got := len(stream.sent()); got != 1 {
+		t.Fatalf("expected only the initial ListAndWatch response in steady state, got %d", got)
+	}
+	if mgr.updates.Load() == 0 {
+		t.Fatal("expected the device cache to be refreshed at least once")
+	}
+}
+
+// TestWatchAndRegister_ContinuesWithoutListAndWatchConsumer makes sure a device
+// change cannot block the loop when kubelet has no ListAndWatch stream open:
+// healthCh is unbuffered, and a blocked send would also stop the HAMi node
+// registration that follows it.
+func TestWatchAndRegister_ContinuesWithoutListAndWatchConsumer(t *testing.T) {
+	original := healthUpdateSendTimeout
+	healthUpdateSendTimeout = 200 * time.Millisecond
+	t.Cleanup(func() { healthUpdateSendTimeout = original })
+
+	mgr := newCachingFakeManager(fakeDevices(4, false)...)
+	ps := newWatchRegisterServer(t, mgr)
+
+	mgr.setHardware(fakeDevices(4, true)...)
+	runWatchAndRegister(t, ps, nil, watchRegisterRunFor)
+
+	for _, dev := range registeredDevices(t, ps) {
+		if !dev.Health {
+			t.Fatalf("expected HAMi registration to keep running and report healthy devices, got %+v", dev)
+		}
+	}
+}


### PR DESCRIPTION
**What type of PR is this?**

Bug fix. This repository has no `kind/*` labels, so the `/kind` command cannot be used here. The `enhancement` label currently on this PR was applied automatically and is not accurate; please relabel it to `bug`.

**What this PR does / why we need it**:

`watchAndRegister` refreshed the cached device view only while `GetUnHealthIDs()` reported at least one unhealthy device:

```go
unhealthy := ps.mgr.GetUnHealthIDs()
if len(unhealthy) > 0 {
    if err := ps.mgr.UpdateDevice(); err != nil { ... }
    ps.healthCh <- unhealthy[0]
}
```

When a device is unhealthy while the plugin starts — a node that boots faster than the Ascend driver initialises — and recovers shortly afterwards, that condition is already false on the next iteration. The cache keeps the startup snapshot forever, and because `ListAndWatch` only sends again when it receives on `healthCh`, kubelet also keeps the startup device list.

The node then advertises no allocatable devices and Pods fail admission with `Allocate failed due to no healthy devices present`, while `npu-smi` reports every device healthy. `registerHAMi()` keeps publishing the same stale snapshot to `hami.io/node-register-<commonWord>`, so the scheduler sees the stale health too. Only restarting the Pod recovers the node. The same condition keeps a partially enumerated device list from ever growing.

This PR:

- refreshes the device cache on every iteration of `watchAndRegister`;
- publishes a `ListAndWatch` update whenever the device set changes, in either direction, using a fingerprint over the published device UUIDs and their health so the steady state stays free of redundant updates;
- bounds the `healthCh` send, so that a missing `ListAndWatch` consumer cannot stall the loop and thereby also stop the HAMi node registration that follows it (`healthCh` is unbuffered);
- adds regression tests for recovery, late device discovery, steady state, and the missing-consumer case.

**Which issue(s) this PR fixes**:

Fixes #129

**Special notes for your reviewer**:

- The change is limited to the device-cache refresh loop. Device allocation, scheduling, resource accounting, vNPU handling, and both slicing modes are untouched; `go.mod` / `go.sum` are unchanged.
- `ListAndWatch` itself is not modified, so this does not overlap with #126 (stream-closure handling); the two are complementary — that PR fixes the consumer side of the stream lifecycle, this one fixes the producer side never producing.
- `healthUpdateSendTimeout` is a package-level variable rather than a constant only so the regression test can shorten it.
- Each of the four new tests fails on `main` and passes with this change:

  | test | failure on `main` |
  |---|---|
  | `TestWatchAndRegister_RepublishesRecoveredDevices` | `expected kubelet to receive an updated device list, got 1 response(s)` |
  | `TestWatchAndRegister_PublishesLateDiscoveredDevices` | `expected 16 devices in the last response, got 8` |
  | `TestWatchAndRegister_SteadyStateDoesNotResend` | `expected the device cache to be refreshed at least once` |
  | `TestWatchAndRegister_ContinuesWithoutListAndWatchConsumer` | registration stops, annotation stays `Health:false` |

Verification performed on macOS/arm64 (`go1.26.6`):

- `make test` — all packages pass
- `go vet ./internal/...` — clean
- `golangci-lint v2.1.0 run ./internal/...` — `0 issues`
- `go test -race -count=5 ./internal/server/ -run TestWatchAndRegister` — clean
- device-plugin binary build — succeeds

Field context: the failure was observed on a two-node RKE2 v1.35.5 cluster with 4 × Ascend 910B4-1 per node running `v1.4.0`, and the observable signature is a disagreement between `hami.io/node-register-<commonWord>` and the device series exported by the plugin's own dcmi collector on `:9395` (the latter reads the hardware live and stays correct during the failure).

**Does this PR introduce a user-facing change?**:

No.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Device availability updates now reflect health recovery and newly discovered devices.
  * Unchanged device lists are no longer resent unnecessarily.
  * Device registration continues reliably even when no consumer is connected.
  * Updates honor shutdown signals and use bounded delivery timeouts.
* **Tests**
  * Added coverage for device recovery, late discovery, steady-state behavior, and registration without an active consumer.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
