### PR TITLE
feat: advertise hami-core Devcore via deviceCoreScaling

### DIFF
--- a/ascend-device-configmap.yaml
+++ b/ascend-device-configmap.yaml
@@ -11,6 +11,7 @@ data:
   device-config.yaml: |-
     vnpus:
       hamiVnpuCore: false
+      deviceCoreScaling: 1
       configs:
       - chipName: 910A
         commonWord: Ascend910A

--- a/ascend-device-node-configmap.yaml
+++ b/ascend-device-node-configmap.yaml
@@ -13,6 +13,7 @@ data:
       - name: "cnst-dev-w2"
         hami-vnpu-core: true
         vDeviceCount: 8
+        deviceCoreScaling: 1
         filterDevices:
           index: []
           uuid: []

--- a/charts/ascend-device-plugin/README.md
+++ b/charts/ascend-device-plugin/README.md
@@ -51,9 +51,34 @@ helm install ascend-device-plugin ./charts/ascend-device-plugin \
   --set hamiVnpuCore.enabled=true
 ```
 
+### Compute Oversell
+
+`hamiVnpuCore.deviceCoreScaling` sets how much compute the plugin advertises for
+hami-core. The plugin registers `Devcore = round(100 * deviceCoreScaling)` and HAMi
+admits `-core` requests against that budget:
+
+```bash
+helm install ascend-device-plugin ./charts/ascend-device-plugin \
+  --namespace kube-system \
+  --set hamiVnpuCore.enabled=true \
+  --set-json hamiVnpuCore.deviceCoreScaling=1.5
+```
+
+Use `--set-json` or a values file for fractional ratios. Plain `--set` parses `1.5` as a
+string, which the chart schema rejects.
+
+With `1.5` the advertised budget is 150, so three pods requesting `-core: "30"` plus one
+requesting `-core: "20"` fit on the same card. The default `1` keeps the 100-point budget
+and preserves current behavior. Ratios below `1` are rejected by the chart schema, and the
+plugin falls back to `1` if the device config sets one directly.
+
+Only compute is oversold. Device memory is never scaled, and pod density per card is
+still capped by `vDeviceCount`, so raising the ratio alone may not admit more pods.
+
 ## Node Configuration
 
-Override `nodeConfig` to enable or customize `hami-vnpu-core` per node:
+Override `nodeConfig` to enable or customize `hami-vnpu-core` per node. Each node may
+also override `deviceCoreScaling`:
 
 ```yaml
 nodeConfig: |-
@@ -61,6 +86,7 @@ nodeConfig: |-
     - name: "ascend-node-1"
       hami-vnpu-core: true
       vDeviceCount: 8
+      deviceCoreScaling: 1.5
 ```
 
 ## Values
@@ -77,6 +103,7 @@ nodeConfig: |-
 | daemonSet.args[4] | string | `"--v=4"` |  |
 | daemonSet.name | string | `"hami-ascend-device-plugin"` | Device plugin DaemonSet name. |
 | fullnameOverride | string | `""` | Override the fully qualified resource name. |
+| hamiVnpuCore.deviceCoreScaling | float | `1` | hami-core compute oversell ratio. The plugin advertises `Devcore = round(100 * deviceCoreScaling)` so HAMi can admit more than 100% of `-core` on one card. Values below 1 are not supported. |
 | hamiVnpuCore.enabled | bool | `false` | Enable hami-vnpu-core in the generated global device configuration. |
 | image.pullPolicy | string | `"IfNotPresent"` | Kubernetes image pull policy. |
 | image.repository | string | `"projecthami/ascend-device-plugin"` | Container image repository. |

--- a/charts/ascend-device-plugin/README.md.gotmpl
+++ b/charts/ascend-device-plugin/README.md.gotmpl
@@ -51,9 +51,34 @@ helm install ascend-device-plugin ./charts/ascend-device-plugin \
   --set hamiVnpuCore.enabled=true
 ```
 
+### Compute Oversell
+
+`hamiVnpuCore.deviceCoreScaling` sets how much compute the plugin advertises for
+hami-core. The plugin registers `Devcore = round(100 * deviceCoreScaling)` and HAMi
+admits `-core` requests against that budget:
+
+```bash
+helm install ascend-device-plugin ./charts/ascend-device-plugin \
+  --namespace kube-system \
+  --set hamiVnpuCore.enabled=true \
+  --set-json hamiVnpuCore.deviceCoreScaling=1.5
+```
+
+Use `--set-json` or a values file for fractional ratios. Plain `--set` parses `1.5` as a
+string, which the chart schema rejects.
+
+With `1.5` the advertised budget is 150, so three pods requesting `-core: "30"` plus one
+requesting `-core: "20"` fit on the same card. The default `1` keeps the 100-point budget
+and preserves current behavior. Ratios below `1` are rejected by the chart schema, and the
+plugin falls back to `1` if the device config sets one directly.
+
+Only compute is oversold. Device memory is never scaled, and pod density per card is
+still capped by `vDeviceCount`, so raising the ratio alone may not admit more pods.
+
 ## Node Configuration
 
-Override `nodeConfig` to enable or customize `hami-vnpu-core` per node:
+Override `nodeConfig` to enable or customize `hami-vnpu-core` per node. Each node may
+also override `deviceCoreScaling`:
 
 ```yaml
 nodeConfig: |-
@@ -61,6 +86,7 @@ nodeConfig: |-
     - name: "ascend-node-1"
       hami-vnpu-core: true
       vDeviceCount: 8
+      deviceCoreScaling: 1.5
 ```
 
 {{ template "chart.valuesSection" . }}

--- a/charts/ascend-device-plugin/values.schema.json
+++ b/charts/ascend-device-plugin/values.schema.json
@@ -64,9 +64,16 @@
         "hamiVnpuCore": {
             "type": "object",
             "required": [
-                "enabled"
+                "enabled",
+                "deviceCoreScaling"
             ],
             "properties": {
+                "deviceCoreScaling": {
+                    "type": [
+                        "number"
+                    ],
+                    "minimum": 1
+                },
                 "enabled": {
                     "type": "boolean"
                 }

--- a/charts/ascend-device-plugin/values.yaml
+++ b/charts/ascend-device-plugin/values.yaml
@@ -78,11 +78,14 @@ hamiVnpuCore: # @schema required:true;additionalProperties:false
   # hamiVnpuCore.enabled -- Enable hami-vnpu-core in the generated global device configuration.
   enabled: false # @schema required:true
 
+  # hamiVnpuCore.deviceCoreScaling -- (float) hami-core compute oversell ratio. The plugin advertises `Devcore = round(100 * deviceCoreScaling)` so HAMi can admit more than 100% of `-core` on one card. Values below 1 are not supported.
+  deviceCoreScaling: 1 # @schema required:true;type:number;minimum:1
+
 # @ignored
 deviceConfig: |- # @schema required:true
   vnpus:
     hamiVnpuCore: {{ .Values.hamiVnpuCore.enabled }}
-    deviceCoreScaling: 1
+    deviceCoreScaling: {{ .Values.hamiVnpuCore.deviceCoreScaling }}
     configs:
     - chipName: 910A
       commonWord: Ascend910A

--- a/charts/ascend-device-plugin/values.yaml
+++ b/charts/ascend-device-plugin/values.yaml
@@ -82,6 +82,7 @@ hamiVnpuCore: # @schema required:true;additionalProperties:false
 deviceConfig: |- # @schema required:true
   vnpus:
     hamiVnpuCore: {{ .Values.hamiVnpuCore.enabled }}
+    deviceCoreScaling: 1
     configs:
     - chipName: 910A
       commonWord: Ascend910A

--- a/internal/manager/manager.go
+++ b/internal/manager/manager.go
@@ -51,6 +51,7 @@ type Manager interface {
 	GetUnHealthIDs() []int32
 	CleanupIdleVNPUs() error
 	IsHamiVnpuCore() bool
+	DeviceCoreScaling() float64
 }
 
 type AscendManager struct {
@@ -372,4 +373,11 @@ func (am *AscendManager) IsHamiVnpuCore() bool {
 		return am.nodeConfig.HamiVnpuCore
 	}
 	return am.globalConfig.VNPUs.HamiVnpuCore
+}
+
+func (am *AscendManager) DeviceCoreScaling() float64 {
+	if am.nodeConfig != nil && am.nodeConfig.DeviceCoreScaling > 0 {
+		return am.nodeConfig.DeviceCoreScaling
+	}
+	return am.globalConfig.VNPUs.DeviceCoreScaling
 }

--- a/internal/manager/manager.go
+++ b/internal/manager/manager.go
@@ -375,8 +375,14 @@ func (am *AscendManager) IsHamiVnpuCore() bool {
 	return am.globalConfig.VNPUs.HamiVnpuCore
 }
 
+// DeviceCoreScaling returns the hami-core oversell ratio in effect, preferring
+// a per-node override over the global value. An override of 0 reads as "not
+// set", matching the omitempty encoding of the field. Every other override is
+// returned as it was written, an invalid one included, so that AdvertisedDevcore
+// reports it and falls back to the percentage base instead of the node silently
+// inheriting the global ratio.
 func (am *AscendManager) DeviceCoreScaling() float64 {
-	if am.nodeConfig != nil && am.nodeConfig.DeviceCoreScaling > 0 {
+	if am.nodeConfig != nil && am.nodeConfig.DeviceCoreScaling != 0 {
 		return am.nodeConfig.DeviceCoreScaling
 	}
 	return am.globalConfig.VNPUs.DeviceCoreScaling

--- a/internal/manager/manager_test.go
+++ b/internal/manager/manager_test.go
@@ -214,3 +214,71 @@ func TestLoadConfigChipNotFound(t *testing.T) {
 		t.Errorf("LoadConfig() error = %v, want it to name the missing chip", err)
 	}
 }
+
+// TestDeviceCoreScaling checks that a per-node override wins over the global
+// ratio and that an invalid override still reaches AdvertisedDevcore's
+// validation instead of silently inheriting the global ratio.
+func TestDeviceCoreScaling(t *testing.T) {
+	const hardwareAICore = 20
+
+	tests := []struct {
+		name        string
+		global      float64
+		nodeConfig  *internal.NodeConfig
+		wantScaling float64
+		wantDevcore int32
+	}{
+		{
+			name:        "no node config -> global ratio",
+			global:      2,
+			nodeConfig:  nil,
+			wantScaling: 2,
+			wantDevcore: 200,
+		},
+		{
+			name:        "node override unset -> global ratio",
+			global:      2,
+			nodeConfig:  &internal.NodeConfig{Name: "node-001"},
+			wantScaling: 2,
+			wantDevcore: 200,
+		},
+		{
+			name:        "node override 1.5 -> honored over the global ratio",
+			global:      2,
+			nodeConfig:  &internal.NodeConfig{Name: "node-001", DeviceCoreScaling: 1.5},
+			wantScaling: 1.5,
+			wantDevcore: 150,
+		},
+		{
+			name:        "negative node override -> percentage base, not the global ratio",
+			global:      2,
+			nodeConfig:  &internal.NodeConfig{Name: "node-001", DeviceCoreScaling: -1},
+			wantScaling: -1,
+			wantDevcore: 100,
+		},
+		{
+			name:        "node override below 1 -> percentage base",
+			global:      2,
+			nodeConfig:  &internal.NodeConfig{Name: "node-001", DeviceCoreScaling: 0.5},
+			wantScaling: 0.5,
+			wantDevcore: 100,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			am := &AscendManager{
+				nodeConfig:   tt.nodeConfig,
+				globalConfig: internal.Config{VNPUs: internal.VNPUsConfig{DeviceCoreScaling: tt.global}},
+			}
+			if got := am.DeviceCoreScaling(); got != tt.wantScaling {
+				t.Fatalf("DeviceCoreScaling() = %v, want %v", got, tt.wantScaling)
+			}
+			got := internal.AdvertisedDevcore(true, am.DeviceCoreScaling(), hardwareAICore)
+			if got != tt.wantDevcore {
+				t.Fatalf("AdvertisedDevcore(true, %v, %d) = %d, want %d",
+					am.DeviceCoreScaling(), hardwareAICore, got, tt.wantDevcore)
+			}
+		})
+	}
+}

--- a/internal/server/fake_manager_test.go
+++ b/internal/server/fake_manager_test.go
@@ -24,15 +24,16 @@ import (
 // Each method delegates to the corresponding Func field if set;
 // otherwise it returns a zero value.
 type FakeManager struct {
-	CommonWordFunc       func() string
-	ResourceNameFunc     func() string
-	VDeviceCountFunc     func() int
-	UpdateDeviceFunc     func() error
-	GetDevicesFunc       func() []*manager.Device
-	GetDeviceByUUIDFunc  func(UUID string) *manager.Device
-	GetUnHealthIDsFunc   func() []int32
-	CleanupIdleVNPUsFunc func() error
-	IsHamiVnpuCoreFunc   func() bool
+	CommonWordFunc        func() string
+	ResourceNameFunc      func() string
+	VDeviceCountFunc      func() int
+	UpdateDeviceFunc      func() error
+	GetDevicesFunc        func() []*manager.Device
+	GetDeviceByUUIDFunc   func(UUID string) *manager.Device
+	GetUnHealthIDsFunc    func() []int32
+	CleanupIdleVNPUsFunc  func() error
+	IsHamiVnpuCoreFunc    func() bool
+	DeviceCoreScalingFunc func() float64
 }
 
 func (f *FakeManager) CommonWord() string {
@@ -96,4 +97,11 @@ func (f *FakeManager) IsHamiVnpuCore() bool {
 		return f.IsHamiVnpuCoreFunc()
 	}
 	return false
+}
+
+func (f *FakeManager) DeviceCoreScaling() float64 {
+	if f.DeviceCoreScalingFunc != nil {
+		return f.DeviceCoreScalingFunc()
+	}
+	return 0
 }

--- a/internal/server/register.go
+++ b/internal/server/register.go
@@ -33,6 +33,7 @@ import (
 
 	"github.com/Project-HAMi/HAMi/pkg/device"
 	"github.com/Project-HAMi/HAMi/pkg/util"
+	"github.com/Project-HAMi/ascend-device-plugin/internal"
 )
 
 // healthUpdateSendTimeout bounds how long watchAndRegister waits for a
@@ -108,10 +109,7 @@ func (ps *PluginServer) registerHAMi() error {
 	apiDevices := make([]*device.DeviceInfo, 0, len(devs))
 	// hami currently believes that the index starts from 0 and is continuous.
 	for i, dev := range devs {
-		devcore := dev.AICore
-		if ps.mgr.IsHamiVnpuCore() {
-			devcore = HamiVnpuCoreMaxPercent
-		}
+		devcore := internal.AdvertisedDevcore(ps.mgr.IsHamiVnpuCore(), ps.mgr.DeviceCoreScaling(), dev.AICore)
 		device := &device.DeviceInfo{
 			Index:   uint(i),
 			ID:      dev.UUID,

--- a/internal/server/register_test.go
+++ b/internal/server/register_test.go
@@ -411,8 +411,8 @@ func TestRegisterHAMi(t *testing.T) {
 				deviceCount: 1,
 				deviceCheck: func(t *testing.T, devs []*device.DeviceInfo) {
 					t.Helper()
-					if devs[0].Devcore != HamiVnpuCoreMaxPercent {
-						t.Fatalf("device Devcore = %d, want %d in hami-vnpu-core mode", devs[0].Devcore, HamiVnpuCoreMaxPercent)
+					if devs[0].Devcore != 100 {
+						t.Fatalf("device Devcore = %d, want 100 in hami-vnpu-core mode", devs[0].Devcore)
 					}
 				},
 				annotationCheck: func(t *testing.T, annos map[string]string) {

--- a/internal/server/register_test.go
+++ b/internal/server/register_test.go
@@ -424,6 +424,37 @@ func TestRegisterHAMi(t *testing.T) {
 			},
 		},
 		{
+			name: "IsHamiVnpuCore_Devcore150",
+			args: registerHAMiArgs{
+				nodeName:      "test-node",
+				registerAnno:  "hami.io/node-register-Ascend310P",
+				handshakeAnno: "hami.io/node-handshake-Ascend310P",
+				mgr: &FakeManager{
+					GetDevicesFunc: func() []*manager.Device {
+						return []*manager.Device{
+							{UUID: "uuid1", Memory: 21527, AICore: 8, Health: true},
+						}
+					},
+					VDeviceCountFunc:      func() int { return 1 },
+					CommonWordFunc:        func() string { return "Ascend310P" },
+					IsHamiVnpuCoreFunc:    func() bool { return true },
+					DeviceCoreScalingFunc: func() float64 { return 1.5 },
+				},
+				nodes: []*v1.Node{
+					{ObjectMeta: metav1.ObjectMeta{Name: "test-node", Annotations: map[string]string{}}},
+				},
+			},
+			want: registerHAMiWant{
+				deviceCount: 1,
+				deviceCheck: func(t *testing.T, devs []*device.DeviceInfo) {
+					t.Helper()
+					if devs[0].Devcore != 150 {
+						t.Fatalf("device Devcore = %d, want 150 when deviceCoreScaling=1.5", devs[0].Devcore)
+					}
+				},
+			},
+		},
+		{
 			name: "IsHamiVnpuCore_False",
 			args: registerHAMiArgs{
 				nodeName:      "test-node",

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -46,11 +46,6 @@ const (
 	VNPUModeAnnotation         = "huawei.com/vnpu-mode"
 	VNPUModeHamiCore           = "hami-core"
 	VNPUNodeSelectorAnnotation = "hami-vnpu-core"
-	// HamiVnpuCoreMaxPercent is the base allocatable core percentage per device
-	// in soft-slice (hami-vnpu-core) mode, where core requests are percentages.
-	// The capacity advertised to HAMi rises above it when deviceCoreScaling
-	// oversells compute; see internal.AdvertisedDevcore.
-	HamiVnpuCoreMaxPercent = 100
 )
 
 var (

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -46,8 +46,10 @@ const (
 	VNPUModeAnnotation         = "huawei.com/vnpu-mode"
 	VNPUModeHamiCore           = "hami-core"
 	VNPUNodeSelectorAnnotation = "hami-vnpu-core"
-	// HamiVnpuCoreMaxPercent is the total allocatable core units per device in
-	// soft-slice (hami-vnpu-core) mode, where core requests are percentages.
+	// HamiVnpuCoreMaxPercent is the base allocatable core percentage per device
+	// in soft-slice (hami-vnpu-core) mode, where core requests are percentages.
+	// The capacity advertised to HAMi rises above it when deviceCoreScaling
+	// oversells compute; see internal.AdvertisedDevcore.
 	HamiVnpuCoreMaxPercent = 100
 )
 

--- a/internal/vnpu.go
+++ b/internal/vnpu.go
@@ -19,6 +19,7 @@ package internal
 import (
 	"encoding/json"
 	"errors"
+	"math"
 	"os"
 
 	"k8s.io/apimachinery/pkg/util/yaml"
@@ -45,8 +46,12 @@ type VNPUConfig struct {
 }
 
 type VNPUsConfig struct {
-	HamiVnpuCore bool         `json:"hamiVnpuCore,omitempty"`
-	Configs      []VNPUConfig `json:"configs"`
+	HamiVnpuCore bool `json:"hamiVnpuCore,omitempty"`
+	// DeviceCoreScaling is the hami-core compute oversell ratio.
+	// When hami-core is on, registerHAMi advertises Devcore = round(100 * DeviceCoreScaling).
+	// Default 1 keeps a 100-point budget. Zero or negative is treated as 1.
+	DeviceCoreScaling float64      `json:"deviceCoreScaling,omitempty"`
+	Configs           []VNPUConfig `json:"configs"`
 }
 
 type Config struct {
@@ -110,14 +115,32 @@ func LoadConfig(path string) (*Config, error) {
 }
 
 type NodeConfig struct {
-	Name          string        `json:"name" yaml:"name"`
-	HamiVnpuCore  bool          `json:"hami-vnpu-core" yaml:"hami-vnpu-core"`
-	VDeviceCount  int           `json:"vDeviceCount" yaml:"vDeviceCount"`
-	FilterDevices FilterDevices `json:"filterDevices,omitempty" yaml:"filterDevices,omitempty"`
+	Name              string        `json:"name" yaml:"name"`
+	HamiVnpuCore      bool          `json:"hami-vnpu-core" yaml:"hami-vnpu-core"`
+	VDeviceCount      int           `json:"vDeviceCount" yaml:"vDeviceCount"`
+	DeviceCoreScaling float64       `json:"deviceCoreScaling,omitempty" yaml:"deviceCoreScaling,omitempty"`
+	FilterDevices     FilterDevices `json:"filterDevices,omitempty" yaml:"filterDevices,omitempty"`
 }
 
 type NodeListConfig struct {
 	Nodes []NodeConfig `json:"nodes" yaml:"nodes"`
+}
+
+// AdvertisedDevcore is the core capacity registered to HAMi.
+// Template/hard-slice mode keeps the hardware AICore. hami-core uses a
+// 100-point percentage scale, optionally oversold by deviceCoreScaling.
+func AdvertisedDevcore(isHamiCore bool, scale float64, hardwareAICore int32) int32 {
+	if !isHamiCore {
+		return hardwareAICore
+	}
+	if scale <= 0 || math.IsNaN(scale) || math.IsInf(scale, 0) {
+		scale = 1
+	}
+	budget := math.Round(100 * scale)
+	if budget < 1 || budget > math.MaxInt32 {
+		return 100
+	}
+	return int32(budget)
 }
 
 func LoadNodeConfig(path string) (*NodeListConfig, error) {

--- a/internal/vnpu.go
+++ b/internal/vnpu.go
@@ -49,7 +49,7 @@ type VNPUsConfig struct {
 	HamiVnpuCore bool `json:"hamiVnpuCore,omitempty"`
 	// DeviceCoreScaling is the hami-core compute oversell ratio.
 	// When hami-core is on, registerHAMi advertises Devcore = round(100 * DeviceCoreScaling).
-	// Default 1 keeps a 100-point budget. Zero or negative is treated as 1.
+	// Default 1 keeps a 100-point budget. Values below 1 are not supported and fall back to 1.
 	DeviceCoreScaling float64      `json:"deviceCoreScaling,omitempty"`
 	Configs           []VNPUConfig `json:"configs"`
 }
@@ -126,19 +126,35 @@ type NodeListConfig struct {
 	Nodes []NodeConfig `json:"nodes" yaml:"nodes"`
 }
 
+// hamiCorePercentBase is the fixed 0-100 percentage scale hami-core `-core`
+// requests are expressed in.
+const hamiCorePercentBase = 100
+
 // AdvertisedDevcore is the core capacity registered to HAMi.
-// Template/hard-slice mode keeps the hardware AICore. hami-core uses a
-// 100-point percentage scale, optionally oversold by deviceCoreScaling.
+// Template/hard-slice mode keeps the hardware AICore. hami-core uses the
+// percentage scale, optionally oversold by deviceCoreScaling.
+//
+// Scaling below 1 is rejected: HAMi cannot tell an under-provisioned percentage
+// such as 50 apart from a hardware AICore count, so the reduced budget would be
+// silently ignored on the scheduler side.
 func AdvertisedDevcore(isHamiCore bool, scale float64, hardwareAICore int32) int32 {
 	if !isHamiCore {
 		return hardwareAICore
 	}
-	if scale <= 0 || math.IsNaN(scale) || math.IsInf(scale, 0) {
-		scale = 1
+	switch {
+	case math.IsNaN(scale) || math.IsInf(scale, 0):
+		klog.Warningf("deviceCoreScaling %v is not a finite number, advertising %d", scale, hamiCorePercentBase)
+		return hamiCorePercentBase
+	case scale == 0:
+		return hamiCorePercentBase
+	case scale < 1:
+		klog.Warningf("deviceCoreScaling %v is below 1, hami-core cannot under-provision compute, advertising %d", scale, hamiCorePercentBase)
+		return hamiCorePercentBase
 	}
-	budget := math.Round(100 * scale)
-	if budget < 1 || budget > math.MaxInt32 {
-		return 100
+	budget := math.Round(hamiCorePercentBase * scale)
+	if budget > math.MaxInt32 {
+		klog.Warningf("deviceCoreScaling %v is out of range, advertising %d", scale, hamiCorePercentBase)
+		return hamiCorePercentBase
 	}
 	return int32(budget)
 }

--- a/internal/vnpu_test.go
+++ b/internal/vnpu_test.go
@@ -17,6 +17,7 @@
 package internal
 
 import (
+	"math"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -292,6 +293,12 @@ func TestAdvertisedDevcore(t *testing.T) {
 		{name: "hami-core 1.0", hami: true, scale: 1, hardware: 20, want: 100},
 		{name: "hami-core 1.5", hami: true, scale: 1.5, hardware: 20, want: 150},
 		{name: "hami-core 2.0", hami: true, scale: 2, hardware: 20, want: 200},
+		{name: "hami-core rounds to the nearest percent", hami: true, scale: 1.234, hardware: 20, want: 123},
+		{name: "hami-core below 1 falls back", hami: true, scale: 0.5, hardware: 20, want: 100},
+		{name: "hami-core negative falls back", hami: true, scale: -2, hardware: 20, want: 100},
+		{name: "hami-core NaN falls back", hami: true, scale: math.NaN(), hardware: 20, want: 100},
+		{name: "hami-core Inf falls back", hami: true, scale: math.Inf(1), hardware: 20, want: 100},
+		{name: "hami-core out of int32 range falls back", hami: true, scale: 1e9, hardware: 20, want: 100},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/vnpu_test.go
+++ b/internal/vnpu_test.go
@@ -277,3 +277,29 @@ func TestIsLegacyVNPUsLayout(t *testing.T) {
 		})
 	}
 }
+
+func TestAdvertisedDevcore(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name     string
+		hami     bool
+		scale    float64
+		hardware int32
+		want     int32
+	}{
+		{name: "template keeps hardware", hami: false, scale: 1.5, hardware: 20, want: 20},
+		{name: "hami-core default", hami: true, scale: 0, hardware: 20, want: 100},
+		{name: "hami-core 1.0", hami: true, scale: 1, hardware: 20, want: 100},
+		{name: "hami-core 1.5", hami: true, scale: 1.5, hardware: 20, want: 150},
+		{name: "hami-core 2.0", hami: true, scale: 2, hardware: 20, want: 200},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := AdvertisedDevcore(tc.hami, tc.scale, tc.hardware)
+			if got != tc.want {
+				t.Fatalf("AdvertisedDevcore(%v, %v, %d)=%d, want %d", tc.hami, tc.scale, tc.hardware, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Scheduler counterpart: https://github.com/Project-HAMi/HAMi/pull/2952
That HAMi PR keeps a 100-point hami-core Fit budget unless this plugin advertises Devcore > 100.

**What this PR does / why we need it**:

NVIDIA already applies `deviceCoreScaling` when the plugin registers `Devcore`. This plugin hardcoded `Devcore = 100` in hami-core (`HamiVnpuCoreMaxPercent`), so compute oversell could not be advertised no matter what the scheduler did.

- `vnpus.deviceCoreScaling` (default 1), optional per-node override in `NodeConfig`
- chart value `hamiVnpuCore.deviceCoreScaling`, schema `minimum: 1`
- hami-core registers `Devcore = round(100 * deviceCoreScaling)`
- template / hard-slice still reports hardware `AICore`
- default 1 keeps today's 100-point budget

The scheduler keeps a 100-point Fit budget unless advertised `Devcore > 100`, so this plugin change is what actually enables oversell. Physical AICore counts (8/20/24/30) are not treated as that percentage.

The first commit left `deviceCoreScaling: 1` as a literal inside `deviceConfig` (`# @ignored`), so `--set` / a values file could not reach it. `c98d025` renders `{{ .Values.hamiVnpuCore.deviceCoreScaling }}` next to `hamiVnpuCore.enabled`. Fractional ratios need `--set-json` (`--set 1.5` becomes a string and the schema rejects the type). That is in the chart README.

```console
$ helm template adp ./charts/ascend-device-plugin --set hamiVnpuCore.enabled=true \
    --set-json hamiVnpuCore.deviceCoreScaling=1.5 | grep deviceCoreScaling
      deviceCoreScaling: 1.5

$ helm template adp ./charts/ascend-device-plugin --set-json hamiVnpuCore.deviceCoreScaling=0.5
Error: values don't meet the specifications of the schema(s) in the following chart(s):
ascend-device-plugin:
- at '/hamiVnpuCore/deviceCoreScaling': minimum: got 0.5, want 1
```

Ratios below 1 are rejected. `AdvertisedDevcore(true, 0.5, 20)` used to return 50, but HAMi cannot tell that apart from a hardware AICore count (8/20/24/30) and clamps anything `<= 100` back to the base, so the cut disappeared with no log. The plugin now falls back to the percentage base and warns; NaN / Inf / out-of-int32 warn too. Rounding: `1.234` -> `123`. Per-node override is shown in `ascend-device-node-configmap.yaml` and the chart README.

`f53444f` only corrects the `HamiVnpuCoreMaxPercent` comment. `registerHAMi` now calls `internal.AdvertisedDevcore`, so 100 is the base percentage, not the advertised total once scaling is above 1. No behavior change.

**Special notes for your reviewer**:

AI assistance: I used Cursor to draft the patch. I reviewed the registration path. Commit messages were written by me.

Validation: `go test ./internal/...` passes, `helm lint` is clean, `README.md` / `values.schema.json` regenerated with `make update-chart-docs` so `make verify-helm-chart` stays green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable VNPU device core scaling with global and per-node overrides.
  * Supports fractional scaling ratios for compute overselling.
  * Advertised compute capacity now reflects scaling while memory and virtual-device limits remain unchanged.
  * Invalid, unsupported, or below-minimum values fall back safely to the default behavior.

* **Documentation**
  * Added Helm configuration guidance, validation details, examples, and compute overselling limitations.

* **Tests**
  * Added coverage for defaults, overrides, rounding, and invalid values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->